### PR TITLE
Fix deprecated warning message in HA 2021.12

### DIFF
--- a/custom_components/jablotron80/alarm_control_panel.py
+++ b/custom_components/jablotron80/alarm_control_panel.py
@@ -254,8 +254,8 @@ class Jablotron80AlarmControl(JablotronEntity,AlarmControlPanelEntity):
 
 
 	@property
-	def device_state_attributes(self) -> Optional[Dict[str, Any]]:
-		attr = super().device_state_attributes
+	def extra_state_attributes(self) -> Optional[Dict[str, Any]]:
+		attr = super().extra_state_attributes
 		return attr
 
 	@property 

--- a/custom_components/jablotron80/jablotronHA.py
+++ b/custom_components/jablotron80/jablotronHA.py
@@ -45,7 +45,7 @@ class JablotronEntity(Entity):
 
 
 	@property
-	def device_state_attributes(self) -> Optional[Dict[str, Any]]:
+	def extra_state_attributes(self) -> Optional[Dict[str, Any]]:
 		attr ={}
 		if not self._object is None and not self._object.type is None:
 			if self._object.type in DEVICES:


### PR DESCRIPTION
status_state_attributes() is deprecated in favour of extra_state_attributes

This causes a warning on startup from HA2021.12