### PR TITLE
Fix various unknown message issues and related bugs I found along the way

### DIFF
--- a/custom_components/jablotron80/alarm_control_panel.py
+++ b/custom_components/jablotron80/alarm_control_panel.py
@@ -254,8 +254,8 @@ class Jablotron80AlarmControl(JablotronEntity,AlarmControlPanelEntity):
 
 
 	@property
-	def device_state_attributes(self) -> Optional[Dict[str, Any]]:
-		attr = super().device_state_attributes
+	def extra_state_attributes(self) -> Optional[Dict[str, Any]]:
+		attr = super().extra_state_attributes
 		return attr
 
 	@property 

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -1497,7 +1497,6 @@ class JA80CentralUnit(object):
 			LOGGER.error(f'Unknown timestamp event data={packet_data}')
 		#crc = data[7]
 		log = f'Date={date_time_obj},event_type={event_name}, {source}:{self.get_device(source).name}'
-		warn = True
 		if warn:
 			LOGGER.warn(log)
 		else:


### PR DESCRIPTION
Sorry, but this is a large PR. It ended up being that way as I had to do a lot of testing and made the various changes as I went.

I've looked over it and think it is most understandable, but there are definitely a few bits to discuss.....

Changes;

Reduce noise in debug log from RF value constantly changing
Improve unexpected error logging with traceback
Reenable logging of types of beep (and added a couple to the list)
Differentiate between PING type messages and BEEP type messages
Recognise that central unit device is for more than tamper, e.g. other faults
Correct issue than some events don't trigger the area **(this required commenting out of some code, which needs debate)**
Improve logging to log event type, device id and device name, trying to make logged warning messages consistent with what is on the control panel
Added recognition of Fault/Loss of communication and restore of comms messages
Added recognition of ARC message sent message
Added processing of unconfirmed alarm message **(this does set the detector to Detected state, that a breaking change)**