### PR TITLE
Set of commits mostly about process_state

### DIFF
--- a/custom_components/jablotron80/binary_sensor.py
+++ b/custom_components/jablotron80/binary_sensor.py
@@ -64,7 +64,7 @@ class JablotronDeviceSensorEntity(JablotronEntity,BinarySensorEntity):
 				return DEVICE_CLASS_SMOKE
 			elif "code" == self._object.type:
 				return DEVICE_CLASS_MOTION
-			elif "tamper alarm" == self._object.type:
+			elif "Control Panel" == self._object.type:
 				return DEVICE_CLASS_PROBLEM
 			elif "power led" == self._object.type:
 				return DEVICE_CLASS_POWER
@@ -73,7 +73,7 @@ class JablotronDeviceSensorEntity(JablotronEntity,BinarySensorEntity):
 		if self._object.type == DEVICE_MOTION_DETECTOR:
 			return DEVICE_CLASS_MOTION
 		if self._object.type == DEVICE_KEYPAD:
-    			return DEVICE_CLASS_PROBLEM
+			return DEVICE_CLASS_PROBLEM
 		if self._object.type == DEVICE_WINDOW_OPENING_DETECTOR:
 			return DEVICE_CLASS_WINDOW
 

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -756,7 +756,7 @@ class JablotronKeyPress():
 	
 	_BEEP_OPTIONS = {
 		# happens when warning appears on keypad (e.g. after alarm)
-		0x0: {'val': '1s', 'desc': '1 subtle (short) beep triggered'}, 0x1: {'val': '1l', 'desc': '1 loud (long) beep triggered'}, 0x2: {'val': '2l', 'desc': '2 loud (long) beeps triggered'}, 0x3: {'val': '3l', 'desc': '3 loud (long) beeps triggered'}, 0x4: {'val': '4s', 'desc': '4 subtle (short) beeps triggered'}, 0x7: {'val': '0', 'desc': 'no audible beep'}, 0x8: {'val': 'in', 'desc': 'Infinite beeping triggered'}, 0xe: {'val': '?', 'desc': 'unknown beep(s) triggered'}
+		0x0: {'val': '1s', 'desc': '1 subtle (short) beep triggered'}, 0x1: {'val': '1l', 'desc': '1 loud (long) beep triggered'}, 0x2: {'val': '2l', 'desc': '2 loud (long) beeps triggered'}, 0x3: {'val': '3l', 'desc': '3 loud (long) beeps triggered'}, 0x4: {'val': '4s', 'desc': '4 subtle (short) beeps triggered'}, 0x7: {'val': '0(1)', 'desc': 'no audible beep(1)'}, 0x8: {'val': '0(2)', 'desc': 'no audible beep(2)'}, 0xe: {'val': '?', 'desc': 'unknown beep(s) triggered'}
 	}
 	@staticmethod
 	def get_key_command(key):

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -1548,29 +1548,11 @@ class JA80CentralUnit(object):
 		elif status in JablotronState.STATES_DISARMED:
 			self.status = JA80CentralUnit.STATUS_NORMAL
 			self._call_zones(function_name="disarm")
-			if activity == 0x10:
-				activity_name = 'Triggered detector'
-				# something is active
-				if detail == 0x00:
-					# no details... ask..
-					self._send_device_query()
-				else:
-					warn = True
-					# set device active
-					self._confirm_device_query()
-					#self._activate_source(detail)
-			elif activity == 0x00:
+
+			if activity == 0x00:
 				# clear active statuses
 				self._clear_triggers()
-			elif activity == 0x09:
-				activity_name = 'Low battery'
-				self._device_battery_low(detail)
-			elif activity == 0x07:
-				warn = True
-				activity_name = "Tamper alarm"
-				#some pir activity
-				#ed 40 07 06 11 00 00 00 3b ff
-				#self._activate_source(detail)
+
 		elif status == JablotronState.ARMED_ABC:
 			self._call_zones(function_name="armed")
 		elif status == JablotronState.ARMED_A:
@@ -1608,7 +1590,7 @@ class JA80CentralUnit(object):
 			# detail = device id
 			self.notify_service()
 		elif status == JablotronState.BYPASS:
-				# detail = device id
+			# detail = device id
 			self.notify_service()
 		elif status == JablotronState.SERVICE_LOADING_SETTINGS:
 			self.notify_service()
@@ -1625,107 +1607,79 @@ class JA80CentralUnit(object):
 			
 			
 		if JablotronState.is_armed_state(status):
-			if activity == 0x00:
-				# normal state 
-				#this might be needed for PIR clearing. What are effects to other sensors like doors?
-				#self._clear_triggers()
-				pass
-			elif activity == 0x06:
-				# sensor active,
-				# detail = sensor id
-				warn = True
-				activity_name = 'Triggered detector'
-				#self._activate_source(detail)
-				#self._get_zone_via_device(detail).alarm(detail)
-			elif activity == 0x04:
-				# key pressed
-				pass
-			elif activity == 0x08:
-				# "Fault" (on keypad), "lost communication with device" in logs
-				activity_name = 'Fault'
-				#self._activate_source(detail)
-			elif activity == 0x10:
-				activity_name = 'Triggered detector'
-				# something is active
-				if detail == 0x00:
-					# no details... ask..
-					self._send_device_query()
-				else:
-					warn = True
-					# set device active
-					self._confirm_device_query()
-					#self._activate_source(detail)
-			elif activity == 0x0d:
-				# 
-				pass
-			elif activity == 0x0c:
-				# 
-				pass
-			elif activity == 0x12:
-				warn = True
-				activity_name = 'Triggered detector'
-				#pir movement
-				#example ed 43 12 3d 0f 04 00 3c 59 ff for device 4
-				#self._activate_source(detail_2)
-			elif activity == 0x14:
-				# Unconfirmed alarm
-				warn = True
-				activity_name = 'Triggered detector'
-				#self._activate_source(detail)
-			else:
-				LOGGER.error(f'Unknown activity received data={packet_data}')
+			pass
 		elif JablotronState.is_service_state(status):
 			self.status = JA80CentralUnit.STATUS_SERVICE
 		elif JablotronState.is_maintenance_state(status):
 			self.status = JA80CentralUnit.STATUS_MAINTENANCE
 		elif JablotronState.is_exit_delay_state(status):
-			if activity == 0x0c:
-				# normal state?
-				#self._deactivate_source(detail)
-				pass
-			elif activity == 0x10:
-				activity_name = 'Triggered detector'
-					# something is active
-				if detail == 0x00:
-					# no details... ask..
-					self._send_device_query()
-				else:
-					warn = True
-					# set device active
-					self._confirm_device_query()
-					#self._activate_source(detail)
-			elif activity == 0x04:
-				# key pressed, is this possible?
-				pass
-			else:
-				LOGGER.error(f'Unknown activity received data={packet_data}')
+			pass
 		elif JablotronState.is_alarm_state(status):
-			if activity == 0x00:
-				# no reason yet
-				pass
-			elif activity == 0x06:
-				warn = True
-				activity_name = 'Triggered detector'
-				# sensor causing alarm,
-				# detail = sensor id
-				# also something in detail_2
-				#self._activate_source(detail)
-			elif activity == 0x04:
-				# key pressed
-				pass
-			elif activity == 0x14:
-				# Unconfirmed alarm
-				warn = True
-				activity_name = 'Triggered detector'
-				#self._activate_source(detail)
-			else:
-				LOGGER.error(f'Unknown activity received data={packet_data}')
+			pass
 		elif JablotronState.is_entering_delay_state(status):
-			# device activation?
 			pass
 
+		if activity == 0x00:
+			pass
+
+		if activity == 0x01:
+			activity_name ="Service Mode"
+
+		if activity == 0x02:
+			activity_name ="Maintenence Mode"
+
+		elif activity == 0x04:
+			activity_name ="key pressed"
+
+		elif activity == 0x06:
+			# trigger during testing, e.g. maintenance mode
+			warn = True
+			activity_name = 'Alarm'
+
+		elif activity == 0x07:
+			warn = True
+			activity_name = "Tamper alarm"
+
+		elif activity == 0x08:
+			# "Fault" (on keypad), "lost communication with device" in logs
+			warn = True
+			activity_name = 'Fault'
+
+		elif activity == 0x09:
+			warn = True
+			activity_name = 'Low battery'
+			self._device_battery_low(detail)
+
+		elif activity == 0x0c:
+			activity_name = 'Exit delay'
+
+		elif activity == 0x0d:
+			activity_name = 'Entrance delay'
+			pass
+
+		elif activity == 0x10:
+			# trigger during standard (unset) mode, e.g. a door open detector
+			activity_name = 'Triggered detector'
+				# something is active
+			if detail == 0x00:
+				# no details... ask..
+				self._send_device_query()
+			else:
+				warn = True
+				# set device active
+				self._confirm_device_query()
+
+		elif activity == 0x12:
+			warn = True
+			activity_name = 'Triggered detector'
+
+		elif activity == 0x14:
+			# Unconfirmed alarm
+			warn = True
+			activity_name = 'Unconfired alarm'
+
 		if activity != 0x00:
-			log = f'Status: {activity}, {activity_name}, {detail}:{self.get_device(detail).name}'
+			log = f'Activity: {activity}, {activity_name}, {detail}:{self.get_device(detail).name}'
 			if warn:
 				LOGGER.warn(log)
 			else:

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -1415,7 +1415,7 @@ class JA80CentralUnit(object):
 			event_name = "Fault"
 			warn = True
 		elif event_type == 0x50:
-			event_name = "End of Tampering"
+			event_name = "End of Tamper alarm"
 			# source is 0 when all tamper alarms have gone
 		elif event_type == 0x11:
 			event_name = "Discharged battery"

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -1509,7 +1509,7 @@ class JA80CentralUnit(object):
 		else:
 			LOGGER.error(f'Unknown timestamp event data={packet_data}')
 		#crc = data[7]
-		log = f'Alarm:{event_name}, {source}:{self.get_device(source).name}, Date={date_time_obj}'
+		log = f'Alarm:{event_name}, {source}:{self._get_source(source).name}, Date={date_time_obj}'
 
 		if warn:
 			LOGGER.warn(log)
@@ -1525,6 +1525,7 @@ class JA80CentralUnit(object):
 
 	def _process_state(self, data: bytearray, packet_data: str) -> None:
 		warn = False
+		log = True
 		activity_name = "Unknown"
 		status = data[1]
 		activity = data[2]
@@ -1633,7 +1634,7 @@ class JA80CentralUnit(object):
 			activity_name ="key pressed"
 
 		elif activity == 0x06:
-			# trigger during testing, e.g. maintenance mode
+			# trigger during testing, i.e. maintenance mode
 			warn = True
 			activity_name = 'Alarm'
 
@@ -1663,41 +1664,41 @@ class JA80CentralUnit(object):
 			activity_name = 'Triggered detector'
 				# something is active
 			if detail == 0x00:
+				log = False
 				# no details... ask..
 				self._send_device_query()
 			else:
 				warn = True
 				# set device active
 				self._confirm_device_query()
+				self._activate_source(detail)
 
 		elif activity == 0x12:
 			warn = True
-			activity_name = 'Triggered detector'
+			activity_name = 'Triggered detector (2)'
 
 		elif activity == 0x14:
 			# Unconfirmed alarm
 			warn = True
-			activity_name = 'Unconfired alarm'
+			activity_name = 'Unconfirmed alarm'
 			
-			# An unconfirmed alarm on control panel (as reported on keypad) reported detail 0x51
-			if detail == 0x51:
-				detail = 0
-
 		if activity != 0x00:
 			if activity_name != "Unknown":
-				log = f'{activity_name}, {detail}:{self.get_device(detail).name}'
+				message = f'{activity_name}, {detail}:{self._get_source(detail).name}'
 			else:
-				log = f'Unknown Activity:{activity}, {detail}:{self.get_device(detail).name}'
+				message = f'Unknown Activity:{activity}, {detail}:{self._get_source(detail).name}'
 
 			# log a warning/info message only once
-			if self._message == log:
-				LOGGER.debug(log)
+			if self._message == message:
+				LOGGER.debug(message)
 			else:
-				self._message = log
-				if warn:
-					LOGGER.warn(log)
-				else:
-					LOGGER.info(log)
+				if log:
+					self._message = message
+					if warn:
+						LOGGER.warn(message)
+						self._activate_source(detail)
+					else:
+						LOGGER.info(message)
 
 		#LOGGER.info(f'Status: {hex(status)}, {format(status, "008b")}')
 		#LOGGER.info(f'{self}')

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -1498,7 +1498,9 @@ class JA80CentralUnit(object):
 			event_name = "Lost communication"
 			warn = True
 		elif event_type == 0x51:
-			event_name = "No issues reported"
+			event_name = "Fault no longer present"
+		elif event_type == 0x52:
+			event_name = "Battery OK"
 		else:
 			LOGGER.error(f'Unknown timestamp event data={packet_data}')
 		#crc = data[7]

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -757,7 +757,7 @@ class JablotronKeyPress():
 	
 	_BEEP_OPTIONS = {
 		# happens when warning appears on keypad (e.g. after alarm)
-		0x0: {'val': '1s', 'desc': '1 subtle (short) beep triggered'}, 0x1: {'val': '1l', 'desc': '1 loud (long) beep triggered'}, 0x2: {'val': '2l', 'desc': '2 loud (long) beeps triggered'}, 0x3: {'val': '3l', 'desc': '3 loud (long) beeps triggered'}, 0x4: {'val': '4s', 'desc': '4 subtle (short) beeps triggered'}, 0x7: {'val': '0(1)', 'desc': 'no audible beep(1)'}, 0x8: {'val': '0(2)', 'desc': 'no audible beep(2)'}, 0xe: {'val': '?', 'desc': 'unknown beep(s) triggered'}
+		0x0: {'val': '1s', 'desc': '1 subtle (short) beep triggered'}, 0x1: {'val': '1l', 'desc': '1 loud (long) beep triggered'}, 0x2: {'val': '2l', 'desc': '2 loud (long) beeps triggered'}, 0x3: {'val': '3l', 'desc': '3 loud (long) beeps triggered'}, 0x4: {'val': '4s', 'desc': '4 subtle (short) beeps triggered'}, 0x5: {'val': '3s', 'desc': '3 subtle (short) beeps, 1 then 2'}, 0x7: {'val': '0(1)', 'desc': 'no audible beep(1)'}, 0x8: {'val': '0(2)', 'desc': 'no audible beep(2)'}, 0xe: {'val': '?', 'desc': 'unknown beep(s) triggered'}
 	}
 	@staticmethod
 	def get_key_command(key):

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -912,7 +912,8 @@ class JablotronMessage():
 				LOGGER.debug(f'Message of type {message_type} received {packet_data}')
 				return message_type
 			else:
-				LOGGER.error(f'Invalid message of type {message_type} received {packet_data}')
+				# likely a corrupt message
+				LOGGER.info(f'Invalid message of type {message_type} received {packet_data}')
 		return None
 	
 class JablotronState():

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -482,7 +482,8 @@ class JablotronZone(JablotronCommon):
 	@check_active     
 	def device_activated(self,device: JablotronDevice ) -> None:
 		if self.status == JablotronZone.STATUS_ARMED or device.reaction == JablotronConstants.REACTION_FIRE_ALARM:
-			self.alarm(device)
+			#self.alarm(device)
+			pass
 			
 	@check_active     
 	def device_deactivated(self,device: JablotronDevice)-> None:
@@ -492,18 +493,17 @@ class JablotronZone(JablotronCommon):
 
 	@check_active     
 	def code_activated(self,code: JablotronCode ) -> None:
-		pass
-		#if self.status == JablotronZone.STATUS_ARMED or code.reaction == JablotronConstants.REACTION_FIRE_ALARM:
-		#	self.alarm(code)
+		if self.status == JablotronZone.STATUS_ARMED or code.reaction == JablotronConstants.REACTION_FIRE_ALARM:
+			#self.alarm(code)
+			pass
 			
 	@check_active     
 	def code_deactivated(self,device: JablotronDevice)-> None:
-		pass
-  		#if self.status == JablotronZone.STATUS_ALARM:
-		#	#self.disarm()
-		#	pass
+		if self.status == JablotronZone.STATUS_ALARM:
+			#self.disarm()
+			pass
 
-			
+	
 	@check_active      
 	def tamper(self,by: Optional[JablotronDevice]  = None) -> None:
 		self.alarm(by)

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -797,6 +797,7 @@ class JablotronMessage():
 		0xe9: TYPE_SETTINGS,
 		0x80: TYPE_KEYPRESS,
 		0xa0: TYPE_BEEP,
+		0xb3: TYPE_PING_OR_OTHER,
 		0xb4: TYPE_PING_OR_OTHER,
 		0xb7: TYPE_BEEP, # beep on set/unset (for all but setting AB)
 		0xb8: TYPE_BEEP, # on setup
@@ -1642,6 +1643,7 @@ class JA80CentralUnit(object):
 		elif JablotronState.is_alarm_state(status):
 			pass
 		elif JablotronState.is_entering_delay_state(status):
+			activity_name = 'Entrance delay (beeps)'
 			pass
 		elif JablotronState.is_disarmed_state(status):
 			pass
@@ -1714,7 +1716,7 @@ class JA80CentralUnit(object):
 			activate = True
 			activity_name = 'Unconfirmed alarm'
 
-		if activity != 0x00:
+		if activity != 0x00 or activity_name != "Unknown":
 			if message is None:
 
 				# Activity 51 is "Control Panel" according to my keypad!

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -394,12 +394,12 @@ class JablotronDevice(JablotronCommon):
 	def __str__(self) -> str:
 		s = f'Device id={self.device_id},model={self.model},reaction={self.reaction},tampered={self.tampered},battery_low={self.battery_low}'
 		if not self.name is None:
-			s+=f'name={self.name},'
+			s+=f',name={self.name}'
 		if not self.zone is None:
-			s+=f'zone={self.zone.name},'
+			s+=f',zone={self.zone.name}'
 		if not self.serial_number is None:
-			s += f'serial={self.serial_number},'
-		s += f'active={self._active}'
+			s += f',serial={self.serial_number}'
+		s += f',active={self._active}'
 		return s
 
 

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -987,8 +987,9 @@ class JablotronState():
 	STATES_ALARM = [ALARM_A,ALARM_B,ALARM_C,ALARM_WITHOUT_ARMING,
 					ALARM_A_SPLIT,ALARM_B_SPLIT,ALARM_C_SPLIT,ALARM_WITHOUT_ARMING_SPLIT]
 	
-	
+	ARMED_ENTRY_DELAY_2 = 0x4a	
 	ARMED_ENTRY_DELAY = 0x4b
+
 	STATES_ENTERING_DELAY = [ARMED_ENTRY_DELAY]
 	STATES_ELEVATED = [SERVICE,MAINTENANCE]
 		
@@ -1417,7 +1418,7 @@ class JA80CentralUnit(object):
 			event_name = "End of Tampering"
 			# source is 0 when all tamper alarms have gone
 		elif event_type == 0x11:
-			event_name = "Low Battery"
+			event_name = "Discharged battery"
 			warn = True
 			self._device_battery_low(source)
 		elif event_type == 0x41:
@@ -1573,6 +1574,8 @@ class JA80CentralUnit(object):
 		#		self._get_zone_via_object(device).entering(device)
 		#		self._activate_source(detail_2)
 			pass
+		elif status == JablotronState.ARMED_ENTRY_DELAY_2:
+			pass
 		elif status == JablotronState.EXIT_DELAY_ABC:
 			self._call_zones(function_name="arming")
 		elif status == JablotronState.EXIT_DELAY_A:
@@ -1601,6 +1604,7 @@ class JA80CentralUnit(object):
 			self.notify_service()
 		elif status == JablotronState.SERVICE:
 			self.notify_service()
+
 		else:
 			LOGGER.error(
 				f'Unknown status message status={status} received data={packet_data}')
@@ -1647,7 +1651,7 @@ class JA80CentralUnit(object):
 
 		elif activity == 0x09:
 			warn = True
-			activity_name = 'Low battery'
+			activity_name = 'Discharged battery'
 			self._device_battery_low(detail)
 
 		elif activity == 0x0c:

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -506,7 +506,8 @@ class JablotronZone(JablotronCommon):
 	
 	@check_active      
 	def tamper(self,by: Optional[JablotronDevice]  = None) -> None:
-		self.alarm(by)
+		#self.alarm(by)
+		pass
 		
 	@check_active
 	def clear(self,by: Optional[JablotronCode] = None) -> None:

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -1678,6 +1678,10 @@ class JA80CentralUnit(object):
 			# Unconfirmed alarm
 			warn = True
 			activity_name = 'Unconfired alarm'
+			
+			# An uncofirmed alarm on control panel (as reported on keypad) reported detail 0x51
+			if detail == 0x51:
+				detail = 0
 
 		if activity != 0x00:
 			log = f'Activity: {activity}, {activity_name}, {detail}:{self.get_device(detail).name}'

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -1679,12 +1679,15 @@ class JA80CentralUnit(object):
 			warn = True
 			activity_name = 'Unconfired alarm'
 			
-			# An uncofirmed alarm on control panel (as reported on keypad) reported detail 0x51
+			# An unconfirmed alarm on control panel (as reported on keypad) reported detail 0x51
 			if detail == 0x51:
 				detail = 0
 
 		if activity != 0x00:
-			log = f'Activity: {activity}, {activity_name}, {detail}:{self.get_device(detail).name}'
+			if activity_name != "Unknown":
+				log = f'{activity_name}, {detail}:{self.get_device(detail).name}'
+			else:
+				log = f'Unknown Activity:{activity}, {detail}:{self.get_device(detail).name}'
 
 			# log a warning/info message only once
 			if self._message == log:

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -1103,7 +1103,8 @@ class JA80CentralUnit(object):
   					"POWER":self._create_led(5,"power","power led")}
 
 		self._last_event_data = None
-  
+		self._message = ""
+
 		self._master_code = config[CONFIGURATION_PASSWORD]
 		# this is in scale 0 - 40, 0 - 100% ?
 		self._rf_level = JablotronSensor(1)
@@ -1502,6 +1503,7 @@ class JA80CentralUnit(object):
 			LOGGER.error(f'Unknown timestamp event data={packet_data}')
 		#crc = data[7]
 		log = f'Date={date_time_obj},event_type={event_name}, {source}:{self.get_device(source).name}'
+
 		if warn:
 			LOGGER.warn(log)
 		else:
@@ -1684,11 +1686,16 @@ class JA80CentralUnit(object):
 
 		if activity != 0x00:
 			log = f'Activity: {activity}, {activity_name}, {detail}:{self.get_device(detail).name}'
-			if warn:
-				LOGGER.warn(log)
-			else:
-				LOGGER.info(log)
 
+			# log a warning/info message only once
+			if self._message == log:
+				LOGGER.debug(log)
+			else:
+				self._message = log
+				if warn:
+					LOGGER.warn(log)
+				else:
+					LOGGER.info(log)
 
 		# LOGGER.info(f'{self}')
 	def _get_timestamp(self, data: bytearray) -> None:

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -3,7 +3,6 @@ import queue
 import time
 import datetime
 from dataclasses import dataclass, field
-from tkinter import messagebox
 import traceback
 from typing import List,Any,Type,Optional,Union
 import binascii

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -963,13 +963,15 @@ class JablotronState():
 	ENROLLMENT = 0x01
 	SERVICE = 0x00
 	SERVICE_LOADING_SETTINGS = 0x05
+	SERVICE_EXITING= 0x08
 	STATES_SERVICE = [ENROLLMENT,
-					SERVICE, SERVICE_LOADING_SETTINGS]
+					SERVICE, SERVICE_LOADING_SETTINGS, SERVICE_EXITING]
 	MAINTENANCE = 0x20
 	BYPASS = 0x21
 	MAINTENANCE_LOADING_SETTINGS = 0x25
+	MAINTENANCE_EXITING= 0x28
 	STATES_MAINTENANCE = [MAINTENANCE,
-						MAINTENANCE_LOADING_SETTINGS, BYPASS]
+						MAINTENANCE_LOADING_SETTINGS, BYPASS, MAINTENANCE_EXITING]
 	
 	#partial
 	ALARM_A = 0x45
@@ -988,11 +990,12 @@ class JablotronState():
 	STATES_ALARM = [ALARM_A,ALARM_B,ALARM_C,ALARM_WITHOUT_ARMING,
 					ALARM_A_SPLIT,ALARM_B_SPLIT,ALARM_C_SPLIT,ALARM_WITHOUT_ARMING_SPLIT]
 	
-	ARMED_ENTRY_DELAY_2 = 0x4a	
-	ARMED_ENTRY_DELAY = 0x4b
+	ARMED_ENTRY_DELAY_A = 0x49
+	ARMED_ENTRY_DELAY_B = 0x4a	
+	ARMED_ENTRY_DELAY_C = 0x4b
 
-	STATES_ENTERING_DELAY = [ARMED_ENTRY_DELAY]
-	STATES_ELEVATED = [SERVICE,MAINTENANCE]
+	STATES_ENTERING_DELAY = [ARMED_ENTRY_DELAY_A, ARMED_ENTRY_DELAY_B, ARMED_ENTRY_DELAY_C]
+	#STATES_ELEVATED = [SERVICE,MAINTENANCE]
 		
 	@staticmethod
 	def is_armed_state(status):
@@ -1003,7 +1006,8 @@ class JablotronState():
 		return status in JablotronState.STATES_DISARMED
 	@staticmethod
 	def is_elevated_state(status):
-		return status in JablotronState.STATES_ELEVATED
+		return JablotronState.is_service_state(status) or JablotronState.is_maintenance_state(status)
+		#return status in JablotronState.STATES_ELEVATED
 	
 	@staticmethod
 	def is_exit_delay_state(status):
@@ -1572,15 +1576,14 @@ class JA80CentralUnit(object):
 			self._call_zone(2,by = detail,function_name="armed")
 		elif status == JablotronState.ARMED_SPLIT_C:
 			self._call_zone(3,by = detail,function_name="armed")
-		elif status == JablotronState.ARMED_ENTRY_DELAY: 
+		elif status == JablotronState.ARMED_ENTRY_DELAY_C: 
 			# is detail 2 device id?
 			#if not detail_2 == 0x00:
 		#		device = self.get_device(detail_2)
 		#		self._get_zone_via_object(device).entering(device)
 		#		self._activate_source(detail_2)
 			pass
-		elif status == JablotronState.ARMED_ENTRY_DELAY_2:
-			pass
+
 		elif status == JablotronState.EXIT_DELAY_ABC:
 			self._call_zones(function_name="arming")
 		elif status == JablotronState.EXIT_DELAY_A:
@@ -1610,10 +1613,7 @@ class JA80CentralUnit(object):
 		elif status == JablotronState.SERVICE:
 			self.notify_service()
 
-		else:
-			LOGGER.error(
-				f'Unknown status message status={status} received data={packet_data}')
-			
+
 			
 		if JablotronState.is_armed_state(status):
 			pass
@@ -1627,14 +1627,21 @@ class JA80CentralUnit(object):
 			pass
 		elif JablotronState.is_entering_delay_state(status):
 			pass
+		elif JablotronState.is_disarmed_state(status):
+			pass
+		else:
+			LOGGER.error(
+				f'Unknown status message status={status} received data={packet_data}')
+			
+
 
 		if activity == 0x00:
 			pass
 
-		if activity == 0x01:
+		elif activity == 0x01:
 			activity_name ="Service Mode"
 
-		if activity == 0x02:
+		elif activity == 0x02:
 			activity_name ="Maintenence Mode"
 
 		elif activity == 0x04:
@@ -1700,7 +1707,9 @@ class JA80CentralUnit(object):
 				else:
 					LOGGER.info(log)
 
-		# LOGGER.info(f'{self}')
+		#LOGGER.info(f'Status: {hex(status)}, {format(status, "008b")}')
+		#LOGGER.info(f'{self}')
+
 	def _get_timestamp(self, data: bytearray) -> None:
 		day = f'{data[0]:02x}'
 		month = f'{data[1]:02x}'

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -1631,7 +1631,7 @@ class JA80CentralUnit(object):
 				# sensor active,
 				# detail = sensor id
 				warn = True
-				activity_name = 'Activity Confirmed (1)'
+				activity_name = 'Activity Detected (1)'
 				self._activate_source(detail)
 				#self._get_zone_via_device(detail).alarm(detail)
 			elif activity == 0x04:
@@ -1643,7 +1643,7 @@ class JA80CentralUnit(object):
 				self._activate_source(detail)
 			elif activity == 0x10:
 				warn = True
-				activity_name = 'Activity Confirmed (2)'
+				activity_name = 'Activity Detected (2)'
 				# something is active
 				if detail == 0x00:
 					# no details... ask..
@@ -1660,14 +1660,14 @@ class JA80CentralUnit(object):
 				pass
 			elif activity == 0x12:
 				warn = True
-				activity_name = 'Activity Confirmed (3)'
+				activity_name = 'Activity Detected (3)'
 				#pir movement
 				#example ed 43 12 3d 0f 04 00 3c 59 ff for device 4
 				self._activate_source(detail_2)
 			elif activity == 0x14:
 				# Unconfirmed alarm
 				warn = True
-				activity_name = 'Unconfirmed alarm'
+				activity_name = 'Activity Detected (4)'
 				self._activate_source(detail)
 			else:
 				LOGGER.error(f'Unknown activity received data={packet_data}')
@@ -1682,7 +1682,7 @@ class JA80CentralUnit(object):
 				pass
 			elif activity == 0x10:
 				warn = True
-				activity_name = 'Activity Confirmed'
+				activity_name = 'Activity Detected (5)'
 					# something is active
 				if detail == 0x00:
 					# no details... ask..
@@ -1708,19 +1708,24 @@ class JA80CentralUnit(object):
 			elif activity == 0x04:
 				# key pressed
 				pass
+			elif activity == 0x14:
+				# Unconfirmed alarm
+				warn = True
+				activity_name = 'Activity Detected (6)'
+				self._activate_source(detail)
 			else:
 				LOGGER.error(f'Unknown activity received data={packet_data}')
 		elif JablotronState.is_entering_delay_state(status):
 			# device activation?
 			pass
 
-		#if activity != 0x00:
-		#	log = f'Status: {activity_name}, {detail}:{self.get_device(detail).name}'
-		#	if warn:
-		#		LOGGER.warn(log)
-		#	else:
-		#		#LOGGER.info(log)
-		#		pass
+		if activity != 0x00:
+			log = f'Status: {activity_name}, {detail}:{self.get_device(detail).name}'
+			if warn:
+				LOGGER.warn(log)
+			else:
+				LOGGER.debug(log)
+
 
 		# LOGGER.info(f'{self}')
 	def _get_timestamp(self, data: bytearray) -> None:
@@ -1955,8 +1960,8 @@ class JA80CentralUnit(object):
 			#keypress = JablotronMessage.get_keypress_option(data[0]& 0x0f)
 			pass
 		elif message_type == JablotronMessage.TYPE_PING_OR_OTHER:
-			LOGGER.warn(f"Ping or Other: {packet_data}")
 			if len(data) != 2:
+				LOGGER.warn(f"Embedded Ping: {packet_data}")
 				# process message without the ping prefix
 				self._process_message(data[1:])
 		elif message_type == JablotronMessage.TYPE_BEEP:

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -1401,7 +1401,7 @@ class JA80CentralUnit(object):
 		source = data[6]
 		# codes 40 master code, 41 - 50 codes 1-10
 		if event_type == 0x05:
-			event_name = "Tampering"
+			event_name = "Tamper alarm"
 			# entering service mode, source = by which id
 			self._device_tampered(source)
 			warn = True
@@ -1549,25 +1549,28 @@ class JA80CentralUnit(object):
 			self.status = JA80CentralUnit.STATUS_NORMAL
 			self._call_zones(function_name="disarm")
 			if activity == 0x10:
-				warn = True
-				activity_name = 'Activity'
+				activity_name = 'Triggered detector'
 				# something is active
 				if detail == 0x00:
 					# no details... ask..
 					self._send_device_query()
 				else:
+					warn = True
 					# set device active
 					self._confirm_device_query()
-					self._activate_source(detail)
+					#self._activate_source(detail)
 			elif activity == 0x00:
 				# clear active statuses
 				self._clear_triggers()
 			elif activity == 0x09:
+				activity_name = 'Low battery'
 				self._device_battery_low(detail)
 			elif activity == 0x07:
+				warn = True
+				activity_name = "Tamper alarm"
 				#some pir activity
 				#ed 40 07 06 11 00 00 00 3b ff
-				self._activate_source(detail)
+				#self._activate_source(detail)
 		elif status == JablotronState.ARMED_ABC:
 			self._call_zones(function_name="armed")
 		elif status == JablotronState.ARMED_A:
@@ -1631,27 +1634,27 @@ class JA80CentralUnit(object):
 				# sensor active,
 				# detail = sensor id
 				warn = True
-				activity_name = 'Activity Detected (1)'
-				self._activate_source(detail)
+				activity_name = 'Triggered detector'
+				#self._activate_source(detail)
 				#self._get_zone_via_device(detail).alarm(detail)
 			elif activity == 0x04:
 				# key pressed
 				pass
 			elif activity == 0x08:
 				# "Fault" (on keypad), "lost communication with device" in logs
-				activity_name = 'Lost communication with device'
-				self._activate_source(detail)
+				activity_name = 'Fault'
+				#self._activate_source(detail)
 			elif activity == 0x10:
-				warn = True
-				activity_name = 'Activity Detected (2)'
+				activity_name = 'Triggered detector'
 				# something is active
 				if detail == 0x00:
 					# no details... ask..
 					self._send_device_query()
 				else:
+					warn = True
 					# set device active
 					self._confirm_device_query()
-					self._activate_source(detail)
+					#self._activate_source(detail)
 			elif activity == 0x0d:
 				# 
 				pass
@@ -1660,15 +1663,15 @@ class JA80CentralUnit(object):
 				pass
 			elif activity == 0x12:
 				warn = True
-				activity_name = 'Activity Detected (3)'
+				activity_name = 'Triggered detector'
 				#pir movement
 				#example ed 43 12 3d 0f 04 00 3c 59 ff for device 4
-				self._activate_source(detail_2)
+				#self._activate_source(detail_2)
 			elif activity == 0x14:
 				# Unconfirmed alarm
 				warn = True
-				activity_name = 'Activity Detected (4)'
-				self._activate_source(detail)
+				activity_name = 'Triggered detector'
+				#self._activate_source(detail)
 			else:
 				LOGGER.error(f'Unknown activity received data={packet_data}')
 		elif JablotronState.is_service_state(status):
@@ -1681,16 +1684,16 @@ class JA80CentralUnit(object):
 				#self._deactivate_source(detail)
 				pass
 			elif activity == 0x10:
-				warn = True
-				activity_name = 'Activity Detected (5)'
+				activity_name = 'Triggered detector'
 					# something is active
 				if detail == 0x00:
 					# no details... ask..
 					self._send_device_query()
 				else:
+					warn = True
 					# set device active
 					self._confirm_device_query()
-					self._activate_source(detail)
+					#self._activate_source(detail)
 			elif activity == 0x04:
 				# key pressed, is this possible?
 				pass
@@ -1701,18 +1704,20 @@ class JA80CentralUnit(object):
 				# no reason yet
 				pass
 			elif activity == 0x06:
+				warn = True
+				activity_name = 'Triggered detector'
 				# sensor causing alarm,
 				# detail = sensor id
 				# also something in detail_2
-				self._activate_source(detail)
+				#self._activate_source(detail)
 			elif activity == 0x04:
 				# key pressed
 				pass
 			elif activity == 0x14:
 				# Unconfirmed alarm
 				warn = True
-				activity_name = 'Activity Detected (6)'
-				self._activate_source(detail)
+				activity_name = 'Triggered detector'
+				#self._activate_source(detail)
 			else:
 				LOGGER.error(f'Unknown activity received data={packet_data}')
 		elif JablotronState.is_entering_delay_state(status):
@@ -1720,11 +1725,11 @@ class JA80CentralUnit(object):
 			pass
 
 		if activity != 0x00:
-			log = f'Status: {activity_name}, {detail}:{self.get_device(detail).name}'
+			log = f'Status: {activity}, {activity_name}, {detail}:{self.get_device(detail).name}'
 			if warn:
 				LOGGER.warn(log)
 			else:
-				LOGGER.debug(log)
+				LOGGER.info(log)
 
 
 		# LOGGER.info(f'{self}')

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -1597,30 +1597,16 @@ class JA80CentralUnit(object):
 			self._call_zone(2,by = detail,function_name="arming")
 		elif status == JablotronState.EXIT_DELAY_SPLIT_C:
 			self._call_zone(3,by = detail,function_name="arming")
-		elif status == JablotronState.ENROLLMENT:
-			# detail = device id
-			self.notify_service()
-		elif status == JablotronState.BYPASS:
-			# detail = device id
-			self.notify_service()
-		elif status == JablotronState.SERVICE_LOADING_SETTINGS:
-			self.notify_service()
-		elif status == JablotronState.MAINTENANCE_LOADING_SETTINGS:
-			self.notify_service()
-		elif status == JablotronState.MAINTENANCE:
-			# at least activity 02
-			self.notify_service()
-		elif status == JablotronState.SERVICE:
-			self.notify_service()
-
 
 			
 		if JablotronState.is_armed_state(status):
 			pass
 		elif JablotronState.is_service_state(status):
 			self.status = JA80CentralUnit.STATUS_SERVICE
+			self.notify_service()
 		elif JablotronState.is_maintenance_state(status):
 			self.status = JA80CentralUnit.STATUS_MAINTENANCE
+			self.notify_service()
 		elif JablotronState.is_exit_delay_state(status):
 			pass
 		elif JablotronState.is_alarm_state(status):
@@ -1632,8 +1618,7 @@ class JA80CentralUnit(object):
 		else:
 			LOGGER.error(
 				f'Unknown status message status={status} received data={packet_data}')
-			
-
+		
 
 		if activity == 0x00:
 			pass

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -3,6 +3,7 @@ import queue
 import time
 import datetime
 from dataclasses import dataclass, field
+from tkinter import messagebox
 import traceback
 from typing import List,Any,Type,Optional,Union
 import binascii
@@ -779,7 +780,8 @@ class JablotronMessage():
 	TYPE_STATE_DETAIL = 'StateDetail'
 	TYPE_KEYPRESS = 'KeyPress'
 	TYPE_BEEP = 'Beep'
-	TYPE_PING = 'Ping' # regular events that have no clear meaning (perhaps yet)
+	TYPE_PING = 'Ping' # regular messages that have no clear meaning (perhaps yet)
+	TYPE_PING_OR_OTHER = 'Ping or Other' # message that have no payload or otherwise the payload is a message of other type
 	TYPE_SAVING = 'Saving'
 	# e8,e9,e5,
 	_MESSAGE_MAIN_TYPES = {
@@ -795,10 +797,10 @@ class JablotronMessage():
 		0xe9: TYPE_SETTINGS,
 		0x80: TYPE_KEYPRESS,
 		0xa0: TYPE_BEEP,
-		0xb4: TYPE_PING,
+		0xb4: TYPE_PING_OR_OTHER,
 		0xb7: TYPE_BEEP, # beep on set/unset (for all but setting AB)
 		0xb8: TYPE_BEEP, # on setup
-		0xba: TYPE_PING,
+		0xba: TYPE_PING_OR_OTHER,
 		0xc6: TYPE_BEEP,
 		0xe7: TYPE_EVENT,
 		0xec: TYPE_SAVING, # seen when saving took really long
@@ -904,7 +906,10 @@ class JablotronMessage():
 					f'Unknown message type {record[0]} with data {packet_data} received')
 			return None
 		else:
-			if JablotronMessage.validate_length(message_type,record) and JablotronMessage.check_crc(record):
+			if message_type == JablotronMessage.TYPE_PING_OR_OTHER:
+				# don't validate length for a PING_OR_OTHER as it's may contains it's own message
+				return message_type
+			elif JablotronMessage.validate_length(message_type,record) and JablotronMessage.check_crc(record):
 				LOGGER.debug(f'Message of type {message_type} received {packet_data}')
 				return message_type
 			else:
@@ -1950,6 +1955,11 @@ class JA80CentralUnit(object):
 		elif message_type == JablotronMessage.TYPE_KEYPRESS:
 			#keypress = JablotronMessage.get_keypress_option(data[0]& 0x0f)
 			pass
+		elif message_type == JablotronMessage.TYPE_PING_OR_OTHER:
+			LOGGER.warn(f"Ping or Other: {packet_data}")
+			if len(data) != 2:
+				# process message without the ping prefix
+				self._process_message(data[1:])
 		elif message_type == JablotronMessage.TYPE_BEEP:
 			beep = JablotronKeyPress.get_beep_option(data[0]& 0x0f)
 			LOGGER.info("Keypad Beep: " + hex(data[0]) + ", " + str(beep['desc']))

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -1509,7 +1509,7 @@ class JA80CentralUnit(object):
 		else:
 			LOGGER.error(f'Unknown timestamp event data={packet_data}')
 		#crc = data[7]
-		log = f'Date={date_time_obj},event_type={event_name}, {source}:{self.get_device(source).name}'
+		log = f'Alarm:{event_name}, {source}:{self.get_device(source).name}, Date={date_time_obj}'
 
 		if warn:
 			LOGGER.warn(log)

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -1934,7 +1934,7 @@ class JA80CentralUnit(object):
 			pass
 		elif message_type == JablotronMessage.TYPE_PING_OR_OTHER:
 			if len(data) != 2:
-				LOGGER.warn(f"Embedded Ping: {packet_data}")
+				LOGGER.debug(f"Embedded Ping: {packet_data}")
 				# process message without the ping prefix
 				self._process_message(data[1:])
 		elif message_type == JablotronMessage.TYPE_BEEP:

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -1497,7 +1497,6 @@ class JA80CentralUnit(object):
 			LOGGER.error(f'Unknown timestamp event data={packet_data}')
 		#crc = data[7]
 		log = f'Date={date_time_obj},event_type={event_name}, {source}:{self.get_device(source).name}'
-		warn = True
 		if warn:
 			LOGGER.warn(log)
 		else:

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -757,7 +757,7 @@ class JablotronKeyPress():
 	
 	_BEEP_OPTIONS = {
 		# happens when warning appears on keypad (e.g. after alarm)
-		0x0: {'val': '1s', 'desc': '1 subtle (short) beep triggered'}, 0x1: {'val': '1l', 'desc': '1 loud (long) beep triggered'}, 0x2: {'val': '2l', 'desc': '2 loud (long) beeps triggered'}, 0x3: {'val': '3l', 'desc': '3 loud (long) beeps triggered'}, 0x4: {'val': '4s', 'desc': '4 subtle (short) beeps triggered'}, 0x6: {'val': '?1', 'desc': 'Unknown beep(s) triggered(1)'} , 0x7: {'val': '0(1)', 'desc': 'no audible beep(1)'}, 0x8: {'val': '0(2)', 'desc': 'no audible beep(2)'}, 0xe: {'val': '?2', 'desc': 'unknown beep(s) triggered(2)'}
+		0x0: {'val': '1s', 'desc': '1 subtle (short) beep triggered'}, 0x1: {'val': '1l', 'desc': '1 loud (long) beep triggered'}, 0x2: {'val': '2l', 'desc': '2 loud (long) beeps triggered'}, 0x3: {'val': '3l', 'desc': '3 loud (long) beeps triggered'}, 0x4: {'val': '4s', 'desc': '4 subtle (short) beeps triggered'}, 0x7: {'val': '0(1)', 'desc': 'no audible beep(1)'}, 0x8: {'val': '0(2)', 'desc': 'no audible beep(2)'}, 0xe: {'val': '?', 'desc': 'unknown beep(s) triggered'}
 	}
 	@staticmethod
 	def get_key_command(key):
@@ -801,7 +801,7 @@ class JablotronMessage():
 		0xb7: TYPE_BEEP, # beep on set/unset (for all but setting AB)
 		0xb8: TYPE_BEEP, # on setup
 		0xba: TYPE_PING_OR_OTHER,
-		0xc6: TYPE_BEEP,
+		0xc6: TYPE_PING,
 		0xe7: TYPE_EVENT,
 		0xec: TYPE_SAVING, # seen when saving took really long
 		0xfe: TYPE_BEEP, # on setup
@@ -992,10 +992,14 @@ class JablotronState():
 					ALARM_A_SPLIT,ALARM_B_SPLIT,ALARM_C_SPLIT,ALARM_WITHOUT_ARMING_SPLIT]
 	
 	ARMED_ENTRY_DELAY_A = 0x49
-	ARMED_ENTRY_DELAY_B = 0x4a	
-	ARMED_ENTRY_DELAY_C = 0x4b
+	ARMED_ENTRY_DELAY_AB = 0x4a	
+	ARMED_ENTRY_DELAY_ABC = 0x4b
+	ARMED_ENTRY_DELAY_A_SPLIT = 0x69
+	ARMED_ENTRY_DELAY_B_SPLIT = 0x6a
+	ARMED_ENTRY_DELAY_C_SPLIT = 0x6b
 
-	STATES_ENTERING_DELAY = [ARMED_ENTRY_DELAY_A, ARMED_ENTRY_DELAY_B, ARMED_ENTRY_DELAY_C]
+	STATES_ENTERING_DELAY = [ARMED_ENTRY_DELAY_A, ARMED_ENTRY_DELAY_AB, ARMED_ENTRY_DELAY_ABC,
+								ARMED_ENTRY_DELAY_A_SPLIT, ARMED_ENTRY_DELAY_B_SPLIT, ARMED_ENTRY_DELAY_C_SPLIT]
 	#STATES_ELEVATED = [SERVICE,MAINTENANCE]
 		
 	@staticmethod
@@ -1290,6 +1294,15 @@ class JA80CentralUnit(object):
 			# TODO convert bytes to int (1-50)
 			return self.get_code(source - 64)
 	
+	def _get_source_name(self, source:bytes) -> str:
+		if source is None:
+			return "Unknown"
+		source_obj = self._get_source(source)
+		if source_obj is None:
+			return "Unknown"
+		else:
+			return source_obj.name
+
 	def get_device(self, id_: int) -> JablotronDevice:
 		if id_ == 0:
 			return self.central_device
@@ -1539,6 +1552,8 @@ class JA80CentralUnit(object):
 		self.led_c = (leds & 0x02) == 0x02
 		self.led_power  = (leds & 0x01) == 0x01
 		self.led_alarm = (leds & 0x10) == 0x10
+		# THe warning triangle is solid
+		self.led_solid_alarm = (leds & 0x20) == 0x20
 		detail_2 = data[5]
 		field_2 = data[6]
 		# this is probably rf strength 00 = 0%, 0A = 10%, 1E = 75%, 28 = 100%?
@@ -1548,17 +1563,18 @@ class JA80CentralUnit(object):
 		# LOGGER.info(f'crc received={crc},={crc:x},calculate={calc},{calc:x}')
 		self._last_state = status
 		if status == JablotronState.ALARM_A or status == JablotronState.ALARM_A_SPLIT:
-#			detail = detail if activity == 0x10 and not detail == 0x00 else None
-			self._call_zone(1,by = detail,function_name="alarm")
+			by = detail if detail != 0x00 else None
+			self._call_zone(1,by = by,function_name="alarm")
 		elif status == JablotronState.ALARM_B or status == JablotronState.ALARM_B_SPLIT:
-#			detail = detail if activity == 0x10 and not detail == 0x00 else None
-			self._call_zone(2,by = detail,function_name="alarm")
+			by = detail if detail != 0x00 else None
+			self._call_zone(2,by = by,function_name="alarm")
 		elif status == JablotronState.ALARM_C or status == JablotronState.ALARM_WITHOUT_ARMING:
-#			detail = detail if activity == 0x10 and not detail == 0x00 else None
-			self._call_zones(detail,function_name="alarm")
+			by = detail if detail != 0x00 else None
+			self._call_zones(by,function_name="alarm")
 		elif status == JablotronState.ALARM_C_SPLIT:
-#			detail = detail if activity == 0x10 and not detail == 0x00 else None
-			self._call_zone(3,by = detail,function_name="alarm")        
+			by = detail if detail != 0x00 else None
+			self._call_zone(3,by = by,function_name="alarm")        
+
 		elif status in JablotronState.STATES_DISARMED:
 			self.status = JA80CentralUnit.STATUS_NORMAL
 			self._call_zones(function_name="disarm")
@@ -1580,13 +1596,22 @@ class JA80CentralUnit(object):
 			self._call_zone(2,by = detail,function_name="armed")
 		elif status == JablotronState.ARMED_SPLIT_C:
 			self._call_zone(3,by = detail,function_name="armed")
-		elif status == JablotronState.ARMED_ENTRY_DELAY_C: 
-			# is detail 2 device id?
-			#if not detail_2 == 0x00:
-		#		device = self.get_device(detail_2)
-		#		self._get_zone_via_object(device).entering(device)
-		#		self._activate_source(detail_2)
-			pass
+
+
+		elif status == JablotronState.ARMED_ENTRY_DELAY_ABC:
+			self._call_zones(by = detail,function_name="entering")
+		elif status == JablotronState.ARMED_ENTRY_DELAY_A:
+			self._call_zone(1,by = detail,function_name="entering")
+		elif status == JablotronState.ARMED_ENTRY_DELAY_AB:
+			self._call_zone(1,by = detail,function_name="entering")
+			self._call_zone(2,by = detail,function_name="entering")
+		elif status == JablotronState.ARMED_ENTRY_DELAY_A_SPLIT:
+			self._call_zone(1,by = detail,function_name="entering")
+		elif status == JablotronState.ARMED_ENTRY_DELAY_B_SPLIT:
+			self._call_zone(2,by = detail,function_name="entering")
+		elif status == JablotronState.ARMED_ENTRY_DELAY_C_SPLIT:
+			self._call_zone(3,by = detail,function_name="entering")
+
 
 		elif status == JablotronState.EXIT_DELAY_ABC:
 			self._call_zones(function_name="arming")
@@ -1656,12 +1681,10 @@ class JA80CentralUnit(object):
 			self._device_battery_low(detail)
 
 		elif activity == 0x0c:
-			activity_name = 'Exit delay'
+			activity_name = 'Exit delay (beeps)'
 
 		elif activity == 0x0d:
-			activity_name = 'Entrance delay'
-			warn = True
-			message = f'{activity_name}, {detail}:{self._get_source(detail).name}, Detail2:{detail_2}'
+			activity_name = 'Entrance (delay)'
 
 		elif activity == 0x10:
 			# trigger during standard (unset) mode, e.g. a door open detector
@@ -1686,16 +1709,19 @@ class JA80CentralUnit(object):
 			warn = True
 			activity_name = 'Unconfirmed alarm'
 
-			# Activity 51 is "Control Panel" according to my keypad!
-			if detail == 0x51:
-				detail = 0
-
 		if activity != 0x00:
 			if message is None:
-				if activity_name != "Unknown":
-					message = f'Warning: {activity_name}, {detail}:{self._get_source(detail).name}'
+
+				# Activity 51 is "Control Panel" according to my keypad!
+				if detail != 51:
+					name = self._get_source_name(detail)
 				else:
-					message = f'Unknown Warning:{activity}, {detail}:{self._get_source(detail).name}'
+					name = self._get_source_name(0)
+
+				if activity_name != "Unknown":
+					message = f'Warning: {activity_name}, {detail}:{name}'
+				else:
+					message = f'Unknown Warning:{activity}, {detail}:{name}'
 
 			# log a warning/info message only once
 			if self._message == message:
@@ -1908,7 +1934,7 @@ class JA80CentralUnit(object):
 			# ???
 			pass
 		elif detail == 0x0b:
-				# ???
+			# ???
 			pass
 		elif detail == 0x0d:
 			# ???

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -1538,9 +1538,10 @@ class JA80CentralUnit(object):
 		self._device_query_pending = False
 
 	def _process_state(self, data: bytearray, packet_data: str) -> None:
-		warn = False
-		log = True
+		warn = False # should a warning message be logged
+		log = True # should a message be logged at all
 		message = None
+		activate = False # should the sensor be activated
 
 		activity_name = "Unknown"
 		status = data[1]
@@ -1664,10 +1665,12 @@ class JA80CentralUnit(object):
 		elif activity == 0x06:
 			# trigger during testing, i.e. maintenance mode
 			warn = True
+			activate = True
 			activity_name = 'Alarm'
 
 		elif activity == 0x07:
 			warn = True
+			activate = True
 			activity_name = "Tamper alarm"
 
 		elif activity == 0x08:
@@ -1684,7 +1687,7 @@ class JA80CentralUnit(object):
 			activity_name = 'Exit delay (beeps)'
 
 		elif activity == 0x0d:
-			activity_name = 'Entrance (delay)'
+			activity_name = 'Entrance delay (beeps)'
 
 		elif activity == 0x10:
 			# trigger during standard (unset) mode, e.g. a door open detector
@@ -1696,17 +1699,19 @@ class JA80CentralUnit(object):
 				self._send_device_query()
 			else:
 				warn = True
+				activate = True
 				# set device active
 				self._confirm_device_query()
-				self._activate_source(detail)
 
 		elif activity == 0x12:
 			warn = True
+			activate = True
 			activity_name = 'Triggered detector (2)'
 
 		elif activity == 0x14:
 			# Unconfirmed alarm
 			warn = True
+			activate = True
 			activity_name = 'Unconfirmed alarm'
 
 		if activity != 0x00:
@@ -1731,9 +1736,11 @@ class JA80CentralUnit(object):
 					self._message = message
 					if warn:
 						LOGGER.warn(message)
-						self._activate_source(detail)
 					else:
 						LOGGER.info(message)
+
+			if activate:
+				self._activate_source(detail)
 
 		#LOGGER.info(f'Status: {hex(status)}, {format(status, "008b")}')
 		#LOGGER.info(f'{self}')
@@ -1930,6 +1937,9 @@ class JA80CentralUnit(object):
 		elif detail == 0x03:
 			# fire alarm /should this alarm all zones?
 			pass
+		elif detail == 0x08:
+			# comes at least when trying to enter service mode while already in service mode
+			pass
 		elif detail == 0x0e:
 			# ???
 			pass
@@ -1942,9 +1952,7 @@ class JA80CentralUnit(object):
 		elif detail == 0x0c:
 			# ???
 			pass
-		elif detail == 0x08:
-			# comes at least when trying to enter service mode while already in service mode
-			pass
+
 		else:
 			LOGGER.error(f'Unknown state detail received data={packet_data}')
 

--- a/custom_components/jablotron80/jablotronHA.py
+++ b/custom_components/jablotron80/jablotronHA.py
@@ -45,7 +45,7 @@ class JablotronEntity(Entity):
 
 
 	@property
-	def device_state_attributes(self) -> Optional[Dict[str, Any]]:
+	def extra_state_attributes(self) -> Optional[Dict[str, Any]]:
 		attr ={}
 		if not self._object is None and not self._object.type is None:
 			if self._object.type in DEVICES:
@@ -59,7 +59,7 @@ class JablotronEntity(Entity):
 			attr["reaction"] = self._object.reaction
 		if not self._object is None and hasattr(self._object,"by"):
 			attr["by"] = self._object.formatted_by
-		for field in ["serial_number","model","manufacturer","id","type","battery_low"]:
+		for field in ["serial_number","model","manufacturer","id","type","battery_low","tampered"]:
 			if not self._object is None and hasattr(self._object,field):
 				value = getattr(self._object,field)
 				if not value is None:

--- a/custom_components/jablotron80/sensor.py
+++ b/custom_components/jablotron80/sensor.py
@@ -21,7 +21,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
 
 class JablotronZoneSensorEntity(JablotronEntity):
 	def __init__(self, zone: JablotronZone,cu: JA80CentralUnit) -> None:
-    		super().__init__(cu, zone) 
+		super().__init__(cu, zone) 
 
 	@property
 	def state(self) -> str:


### PR DESCRIPTION
Sorry, once again a large PR. It end up being this way as a lot of the changes are in same code area and I'm testing multiple changes at the same time. If you are unhappy with this, I'll attempt to pull them apart now they are all working together and submit separately.

Changes as follows:

* Added "tampered" attribute to HA entities. The intent looked there, but it was not actually exposed
* Handle all entry delay states
* Added handling of various new states
* Tidy device activation code and logging
* Add another BEEP options
* Changed a BEEP to a PING (issue #2)
* Correct debug message delimiting
* Don't ever set the alarm state, let the control panel itself determined that
* Attempt for all warning in the logs to be consistent with what is displayed on control panel
* Quietened errors for corrupt messages (though deal with ping messages that have got a full message inside them, which seem to happen quite a lot and was fairly easy to recognise)
* Recognise battery OK message
* Added an additional led status (not yet exposed in HA)