### PR TITLE
Fix Naming issues

### DIFF
--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -225,7 +225,7 @@ class JablotronCommon:
 	@zone.setter
 	def zone(self, zone:Any) -> None:
 		self._zone = zone
-	
+
 	@active.setter
 	@log_change
 	def active(self,active: bool) -> None:

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -1212,7 +1212,7 @@ class JA80CentralUnit(object):
 		self.central_device = JablotronControlPanel(0)
 		self.central_device.model = CENTRAL_UNIT_MODEL
 		# device that receives fault alerts such as tamper alarms and communication failures
-		self.central_device.name = "Control panel"
+		self.central_device.name = f'{CENTRAL_UNIT_MODEL} Control panel'
 		self.central_device.manufacturer = MANUFACTURER
 		self.central_device.type = DEVICE_CONTROL_PANEL
 		self._devices = {}

--- a/custom_components/jablotron80/jablotronHA.py
+++ b/custom_components/jablotron80/jablotronHA.py
@@ -7,7 +7,7 @@ from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 class JablotronEntity(Entity):
-	
+
 	def __init__(
 			self,
 			cu: JA80CentralUnit,
@@ -85,7 +85,10 @@ class JablotronEntity(Entity):
 		#	return
 		#self._state = state
 
-	
+		# override internal configured name is it's been setup in the UI
+		if self.registry_entry.name is not None:
+			self._object.name = self.registry_entry.name
+
 	async def async_will_remove_from_hass(self) -> None:
 		"""Entity being removed from hass."""
 		self._object.remove_callback(self.async_write_ha_state)


### PR DESCRIPTION
I inadvertently changed the default entity name of control panel, when I was just trying to change the display name.

This changes undoes that and supports the use of the name set in the UI rather than just the one set in configuration at setup time.

This paves the way for an easier setup in future I hope, where device names/ids can be left as just their device number/serial number and then edited in the UI which will in turn also be reflected in error/events messages 