### PR TITLE
Major Refactor of Connection

### DIFF
--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -610,8 +610,17 @@ class JablotronCommand():
 	def __str__(self) -> str:
 		s = f'Command name={self.name}'
 		return s
-	
+
+
+
 class JablotronConnection():
+
+	@staticmethod
+	def factory(cable_model: str, serial_port: str):
+		if cable_model == CABLE_MODEL_JA82T:
+			return JablotronConnectionHID(serial_port)
+		else:
+			return JablotronConnectionSerial(serial_port)
 
 	# device is mandatory at initiation
 	def __init__(self, device: str) -> None:
@@ -1285,9 +1294,7 @@ class JA80CentralUnit(object):
 		self._config: Dict[str, Any] = config
 		self._options: Dict[str, Any] = options
 		self._settings = JablotronSettings()
-#		self._connection = JablotronConnection(CABLE_MODEL_JA80T,'socket://192.168.0.8:23?logging=debug')
-#		self._connection = JablotronConnection(config[CABLE_MODEL],config[CONFIGURATION_SERIAL_PORT])
-		self._connection = JablotronConnectionSerial(config[CONFIGURATION_SERIAL_PORT])
+		self._connection = JablotronConnection.factory(config[CABLE_MODEL], config[CONFIGURATION_SERIAL_PORT])
 		device_count = config[CONFIGURATION_NUMBER_OF_DEVICES]
 		if device_count == 0:
 			self._max_number_of_devices = MAX_NUMBER_OF_DEVICES

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -1286,11 +1286,11 @@ class JA80CentralUnit(object):
 #		self._connection = JablotronConnection(CABLE_MODEL_JA80T,'socket://192.168.0.8:23?logging=debug')
 #		self._connection = JablotronConnection(config[CABLE_MODEL],config[CONFIGURATION_SERIAL_PORT])
 		self._connection = JablotronConnectionSerial(config[CONFIGURATION_SERIAL_PORT])
-#		device_count = config[CONFIGURATION_NUMBER_OF_DEVICES]
-#		if device_count == 0:
-#			self._max_number_of_devices = MAX_NUMBER_OF_DEVICES
-#		else:
-#			self._max_number_of_devices = config[CONFIGURATION_NUMBER_OF_DEVICES]
+		device_count = config[CONFIGURATION_NUMBER_OF_DEVICES]
+		if device_count == 0:
+			self._max_number_of_devices = MAX_NUMBER_OF_DEVICES
+		else:
+			self._max_number_of_devices = config[CONFIGURATION_NUMBER_OF_DEVICES]
 		self._zones = {}
 		self._zones[1] = JablotronZone(1)  
 		self._zones[2] = JablotronZone(2)  

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -716,7 +716,7 @@ class JablotronConnection():
 
 					accepted = False
 					confirmed = False
-					retries = 1
+					retries = 2
 
 					while retries >= 0 and not (accepted and confirmed):
 						retries -=1

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -2413,7 +2413,7 @@ class JA80CentralUnit(object):
 			pass
 		elif JablotronState.is_disarmed_state(self._last_state):
 			self.send_elevated_mode_command()
-			self.send_key_press(code, b'\xa1')
+			self.send_keypress_sequence(code, b'\xa1')
 		elif self._last_state == JablotronState.BYPASS:
 			self.send_return_mode_command()
 		elif self._last_state == None:
@@ -2443,7 +2443,7 @@ class JA80CentralUnit(object):
 			return result
 		return False
 
-	def send_key_press(self, key: str, accepted_prefix: bytes) -> None:
+	def send_keypress_sequence(self, key_sequence: str, accepted_prefix: bytes) -> None:
 
 		value = b''
 
@@ -2452,12 +2452,12 @@ class JA80CentralUnit(object):
 		else:
 			name = str
 		
-		for i in range(0, len(key)):
-			cmd = key[i] 
+		for i in range(0, len(key_sequence)):
+			cmd = key_sequence[i] 
 			value = value + JablotronKeyPress.get_key_command(cmd)
 
 		self._connection.add_command(
-			JablotronCommand(name=f'keypress {name}',code=value, accepted_prefix=accepted_prefix + b'\xff'))
+			JablotronCommand(name=f'key sequence {name}',code=value, accepted_prefix=accepted_prefix + b'\xff'))
 			
 	def shutdown(self) -> None:
 		self._stop.set()
@@ -2466,12 +2466,12 @@ class JA80CentralUnit(object):
 
 	def arm(self,code: str,zone:str=None) -> None:
 		if zone is None:
-			self.send_key_press(code, b'\xa1')
+			self.send_keypress_sequence(code, b'\xa1')
 		else:
-			self.send_key_press({"A":"*2","B":"*3","C":"*1"}[zone]+code, b'\xa1')
+			self.send_keypress_sequence({"A":"*2","B":"*3","C":"*1"}[zone]+code, b'\xa1')
 	
 	def disarm(self,code:str,zone:str=None) -> None:
-		self.send_key_press(code, b'\xa2')
+		self.send_keypress_sequence(code, b'\xa2')
 		if JablotronState.is_alarm_state(self._last_state):
 			#confirm alarm
 			self.send_detail_command

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -905,7 +905,6 @@ class JablotronMessage():
 	TYPE_KEYPRESS = 'KeyPress'
 	TYPE_BEEP = 'Beep'
 	TYPE_PING = 'Ping' # regular messages that have no clear meaning (perhaps yet)
-	TYPE_PING_OR_OTHER = 'Ping or Other' # message that have no payload or otherwise the payload is a message of other type
 	TYPE_SAVING = 'Saving'
 	TYPE_CONFIRM = 'Confirm'
 	# e8,e9,e5,
@@ -922,11 +921,11 @@ class JablotronMessage():
 		0xe9: TYPE_SETTINGS,
 		0x80: TYPE_KEYPRESS,
 		0xa0: TYPE_BEEP,
-		0xb3: TYPE_PING_OR_OTHER,
-		0xb4: TYPE_PING_OR_OTHER,
+		0xb3: TYPE_PING,
+		0xb4: TYPE_PING,
 		0xb7: TYPE_BEEP, # beep on set/unset (for all but setting AB)
 		0xb8: TYPE_BEEP, # on setup
-		0xba: TYPE_PING_OR_OTHER,
+		0xba: TYPE_PING,
 		0xc6: TYPE_PING,
 		0xe7: TYPE_EVENT,
 		0xec: TYPE_SAVING,
@@ -1055,10 +1054,7 @@ class JablotronMessage():
 		if message_type is None:
 			LOGGER.error(f'Unknown message type {hex(record[0])} with data {packet_data} received')
 		else:
-			if message_type == JablotronMessage.TYPE_PING_OR_OTHER:
-				# don't validate length for a PING_OR_OTHER as it's may contains it's own message
-				return message_type
-			elif not JablotronMessage.check_crc(record):
+			if not JablotronMessage.check_crc(record):
 				LOGGER.warn(f'Invalid CRC for {packet_data}')
 			elif JablotronMessage.validate_length(message_type,record):
 				LOGGER.debug(f'Message of type {message_type} received {packet_data}')
@@ -2344,11 +2340,6 @@ class JA80CentralUnit(object):
 		elif message_type == JablotronMessage.TYPE_KEYPRESS:
 			#keypress = JablotronMessage.get_keypress_option(data[0]& 0x0f)
 			pass
-		elif message_type == JablotronMessage.TYPE_PING_OR_OTHER:
-			if len(data) != 2:
-				LOGGER.debug(f"Embedded Ping: {packet_data}")
-				# process message without the ping prefix
-				self._process_message(data[1:])
 		elif message_type == JablotronMessage.TYPE_BEEP:
 			beep = JablotronKeyPress.get_beep_option(data[0]& 0x0f)
 			LOGGER.info("Keypad Beep: " + hex(data[0]) + ", " + str(beep['desc']))

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -726,15 +726,15 @@ class JablotronConnection():
 
 							if not send_cmd.code is None:
 								cmd = self._get_cmd(send_cmd.code[i].to_bytes(1,byteorder='big'))
-								LOGGER.debug(f'Sending new command {cmd}')
+								LOGGER.debug(f'Sending keypress, sequence:{i}')
 								self._connection.write(cmd)
-								LOGGER.debug(f'Command sent {cmd}')
+								LOGGER.debug(f'keypress sent, sequence:{i}')
 
 							if self.read_until_found(accepted_prefix):
-								LOGGER.info(f"command {cmd} accepted")
+								LOGGER.debug(f'keypress accepted, sequence:{i}')
 								accepted = True
 							else:
-								LOGGER.warn(f"no accepted message for command {send_cmd} received")
+								LOGGER.warn(f'no accepted message for sequence:{i} received')
 								accepted = False
 								break # break from for loop into retry loop, has effect of starting full command sequence from scratch
 
@@ -742,7 +742,7 @@ class JablotronConnection():
 							if send_cmd.complete_prefix is not None:
 								# confirmation required, read until confirmation or to limit
 								if self.read_until_found(send_cmd.complete_prefix, send_cmd.max_records):
-									LOGGER.info(f"command {send_cmd} completed")
+									LOGGER.debug(f"command {send_cmd} completed")
 								else:
 									LOGGER.warn(f"no completion message found for command {send_cmd}")
 									send_cmd.confirm(False)

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -592,6 +592,7 @@ class JablotronCommand():
 	code: str = None
 	confirmation_required: bool = True
 	confirm_prefix: str = None
+	accepted_prefix: str = None
 	max_records: int = 10
 	
 	def __post_init__(self) -> None:
@@ -714,7 +715,6 @@ class JablotronConnection():
 						LOGGER.debug(f'Command sent {cmd}')
 					if send_cmd.confirmation_required:
 						# confirmation required, read until confirmation or to limit
-						records_cmd = []
 						for i in range(send_cmd.max_records):
 							if confirmed:
 								break 
@@ -856,12 +856,31 @@ class JablotronKeyPress():
 		"*": b'\x8f'
 	}
 	_KEYPRESS_OPTIONS = {
-		0x0: {'val': '0', 'desc': 'Key 0 pressed on keypad'}, 0x1: {'val': '1', 'desc': 'Key 1 (^) pressed on keypad'}, 0x2: {'val': '2', 'desc': 'Key 2 pressed on keypad'}, 0x3: {'val': '3', 'desc': 'Key 3 pressed on keypad'}, 0x4: {'val': '4', 'desc': 'Key 4 (<) pressed on keypad'}, 0x5: {'val': '5', 'desc': 'Key 5 pressed on keypad'}, 0x6: {'val': '6', 'desc': 'Key 6 (>) pressed on keypad'}, 0x7: {'val': '7', 'desc': 'Key 7 (v) pressed on keypad'}, 0x8: {'val': '8', 'desc': 'Key 8 pressed on keypad'}, 0x9: {'val': '9', 'desc': 'Key 9 pressed on keypad'}, 0xe: {'val': '#', 'desc': 'Key # (ESC/OFF) pressed on keypad'}, 0xf: {'val': '*', 'desc': 'Key * (ON) pressed on keypad'}
+		0x0: {'val': '0', 'desc': 'Key 0 pressed on keypad'}, 
+		0x1: {'val': '1', 'desc': 'Key 1 (^) pressed on keypad'},
+		0x2: {'val': '2', 'desc': 'Key 2 pressed on keypad'},
+		0x3: {'val': '3', 'desc': 'Key 3 pressed on keypad'}, 
+	 	0x4: {'val': '4', 'desc': 'Key 4 (<) pressed on keypad'}, 
+		0x5: {'val': '5', 'desc': 'Key 5 pressed on keypad'}, 
+		0x6: {'val': '6', 'desc': 'Key 6 (>) pressed on keypad'},
+		0x7: {'val': '7', 'desc': 'Key 7 (v) pressed on keypad'},
+		0x8: {'val': '8', 'desc': 'Key 8 pressed on keypad'}, 
+		0x9: {'val': '9', 'desc': 'Key 9 pressed on keypad'}, 
+		0xe: {'val': '#', 'desc': 'Key # (ESC/OFF) pressed on keypad'}, 
+		0xf: {'val': '*', 'desc': 'Key * (ON) pressed on keypad'}
 	}
 	
 	_BEEP_OPTIONS = {
 		# happens when warning appears on keypad (e.g. after alarm)
-		0x0: {'val': '1s', 'desc': '1 subtle (short) beep triggered'}, 0x1: {'val': '1l', 'desc': '1 loud (long) beep triggered'}, 0x2: {'val': '2l', 'desc': '2 loud (long) beeps triggered'}, 0x3: {'val': '3l', 'desc': '3 loud (long) beeps triggered'}, 0x4: {'val': '4s', 'desc': '4 subtle (short) beeps triggered'}, 0x5: {'val': '3s', 'desc': '3 subtle (short) beeps, 1 then 2'}, 0x7: {'val': '0(1)', 'desc': 'no audible beep(1)'}, 0x8: {'val': '0(2)', 'desc': 'no audible beep(2)'}, 0xe: {'val': '?', 'desc': 'unknown beep(s) triggered'}
+		0x0: {'val': '1s', 'desc': '1 subtle (short) beep triggered'},
+	 	0x1: {'val': '1l', 'desc': '1 loud (long) beep triggered'},
+		0x2: {'val': '2l', 'desc': '2 loud (long) beeps triggered'},
+		0x3: {'val': '3l', 'desc': '3 loud (long) beeps triggered'},
+		0x4: {'val': '4s', 'desc': '4 subtle (short) beeps triggered'},
+		0x5: {'val': '3s', 'desc': '3 subtle (short) beeps, 1 then 2'},
+		0x7: {'val': '0(1)', 'desc': 'no audible beep(1)'},
+		0x8: {'val': '0(2)', 'desc': 'no audible beep(2)'},
+		0xe: {'val': '?', 'desc': 'unknown beep(s) triggered'}
 	}
 	@staticmethod
 	def get_key_command(key):
@@ -2363,25 +2382,25 @@ class JA80CentralUnit(object):
 	def send_elevated_mode_command(self) -> None: 
 		if not self._system_status in self.STATUS_ELEVATED:
 			self._connection.add_command(JablotronCommand(name="Elevated mode first part",
-				code=b'\x8f', confirm_prefix=b'\x8f'))
+				code=b'\x8f', confirm_prefix=b'\xa0\xff'))
 			self._connection.add_command(JablotronCommand(name="Elevated mode second part",
-				code=b'\x80', confirm_prefix=b'\x80'))
+				code=b'\x80', confirm_prefix=b'\xa0\xff'))
 
 	def send_return_mode_command(self) -> None:
 		#if self.system_status in self.STATUS_ELEVATED:
 		self._connection.add_command(JablotronCommand(name="Esc / back",
-			code=b'\x8e', confirm_prefix=b'\x8e'))
+			code=b'\x8e', confirm_prefix=b'\xa1\xff'))
 
 	async def send_settings_command(self) -> None:
 		#if self.system_status in self.STATUS_ELEVATED:
 		command = JablotronCommand(name="Get settings",
-				code=b'\x8a', confirm_prefix=b'\xe6\x04', max_records=300)
+				code=b'\x8a', accepted_prefix=b'\xa4\xff', confirm_prefix=b'\xe6\x04', max_records=300)
 		self._connection.add_command(command)
 		return await command.wait_for_confirmation()
 
 	def send_detail_command(self) -> None:
 		self._connection.add_command(JablotronCommand(name="Details",
-			code=b'\x8e', confirm_prefix=b'\x8e'))
+			code=b'\x8e', confirm_prefix=b'\xa4\xff'))
 
 	def enter_elevated_mode(self, code: str) -> bool:
 		# mode service/maintenance depends on pin send after this
@@ -2421,13 +2440,19 @@ class JA80CentralUnit(object):
 		return False
 
 	def send_key_press(self, key: str) -> None:
-		for cmd in key:
+		for i in range(0, len(key)):
+			cmd = key[i] 
 			value = JablotronKeyPress.get_key_command(cmd)
 			name = cmd
 			if JablotronSettings.HIDE_KEY_PRESS:
 				name = "*HIDDEN*"
+			if i == len(key)-1:
+				confirm=b'\xa1\xff'
+			else:
+				confirm=b'\xa0\xff'
 			self._connection.add_command(
-				JablotronCommand(name=f'keypress {name}',code=value, confirm_prefix=value))
+
+				JablotronCommand(name=f'keypress {name}',code=value, confirm_prefix=confirm))
 			
 	def shutdown(self) -> None:
 		self._stop.set()


### PR DESCRIPTION
Refactors and improvements of Connections to improve reliability.

This groups key presses into a single JablotonCommand and then wraps retires around this.

Different "accepted" codes are spotted for different command types and absence of those triggers retries.

While this is tested, I wouldn't say it is ready for packaging as a release yet, but it is worthy of merging pending my next PR which looks at the setup process.