### PR TITLE
Fix for not clearing triggers in unarmed case

### DIFF
--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -1992,7 +1992,7 @@ class JA80CentralUnit(object):
 			self.status = JA80CentralUnit.STATUS_NORMAL
 			self._call_zones(function_name="disarm")
 
-			if activity == 0x00 and not self.led_alarm:
+			if activity == 0x00:# and not self.led_alarm:
 				# clear active statuses
 				self._clear_triggers()
 


### PR DESCRIPTION
This seems to be the issue of not clearing triggers in unarmed case. I had situation where battery was low and that caused alarm led to be on and in that case triggers were not cleared at all in unarmed case.