### PR TITLE
Fix for Issue#165: Unhandled exceptions during reconnection

### DIFF
--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -889,7 +889,9 @@ class JablotronConnectionSerial(JablotronConnection):
 				if "timed out" in f'{ex}':
 					LOGGER.info('Timeout, retrying')
 				elif "Connection refused" in f'{ex}':
-					LOGGER.info('Connection refused by remote host, retrying')
+					LOGGER.info('Connection refused by remote serial host, retrying')
+				elif "unreachable" in f'{ex}':
+					LOGGER.info('Remote serial host is currently unreachable, retrying')
 				else:
 					raise
 

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -888,6 +888,8 @@ class JablotronConnectionSerial(JablotronConnection):
 			except serial.SerialException as ex:
 				if "timed out" in f'{ex}':
 					LOGGER.info('Timeout, retrying')
+				elif "Connection refused" in f'{ex}':
+					LOGGER.info('Connection refused by remote host, retrying')
 				else:
 					raise
 


### PR DESCRIPTION
Fix for Issue#165. If the Network connection to the remote serial host is lost, it results in an Connection refused or Host unreachable exception. I just added an if clause, so the loop continues trying to reconnect. This seems to fix the issue. Maybe it`s smarter to except all SerialExceptions and continue to retry?