### PR TITLE
Fix homeassistant.log showing debug level logs by default

### DIFF
--- a/custom_components/jablotron80/const.py
+++ b/custom_components/jablotron80/const.py
@@ -40,9 +40,10 @@ DEFAULT_CONFIGURATION_REQUIRE_CODE_TO_DISARM = True
 DEFAULT_CONFIGURATION_QUIETEN_EXPECTED_WARNINGS = False
 DEFAULT_CONFIGURATION_VERBOSE_CONNECTION_LOGGING = False
 
-LOGGER.setLevel(logging.DEBUG)
+# Set default Log Level to Debug
+# LOGGER.setLevel(logging.DEBUG)
 handler = logging.StreamHandler(sys.stdout)
-handler.setLevel(logging.DEBUG)
+# handler.setLevel(logging.DEBUG)
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 handler.setFormatter(formatter)
 LOGGER.addHandler(handler)


### PR DESCRIPTION
Setting LOGGER and handler level to DEBUG by default causes lots of DEBUG level entries coming from this extension by default. DEBUG log entries cannot be disabled by changing the log level in configuration.,yaml

Removing the lines below from constants enables the following log behavior:
- Debug Entries are not logged by default
- Setting log level for this extension in configuration.yaml to debug makes debug level entries appear in homeassistant.log.  