### PR TITLE
Prevent the error "task_done() called too many times"

### DIFF
--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -794,9 +794,10 @@ class JablotronConnection:
                             send_cmd.confirm(True)
                             if send_cmd.name == "Details":
                                 self.update_devices = True
-                            self._cmd_q.task_done()
 
                         retries -= 1
+
+                    self._cmd_q.task_done()
 
             except Exception:
                 LOGGER.exception("Unexpected error in packet loop")


### PR DESCRIPTION
Move `self._cmd_q.task_done()` outside the while loop.

Fixes issue #192.