### PR TITLE
Fix #167/#168: gate detail-query cycling + restore per-sensor close (multiple active wireless sensors)

### DIFF
--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -672,6 +672,10 @@ class JablotronConnection:
         # #97: track when we last received data so a watchdog can detect a
         # silently dead connection (the HID read blocks without a timeout).
         self._last_data_time = time.monotonic()
+        # #153/#167 (heifisch): de-duplicate the repeated detail query so it
+        # doesn't pile up behind itself and block disarm.
+        self._cmd_list = []
+        self._send_cmd = None
 
     @property
     def seconds_since_last_data(self) -> float:
@@ -713,13 +717,25 @@ class JablotronConnection:
         return self._connection is not None
 
     async def add_command(self, command: JablotronCommand) -> None:
+        # #153/#167 (heifisch): de-duplicate ONLY the automatic "Details" detail
+        # query so repeated background queries don't pile up behind each other and
+        # block disarm. User/functional commands (arm, disarm, settings) are never
+        # de-duplicated, so a deliberately repeated arm/disarm sequence still goes
+        # through every time.
+        if command.name == "Details" and (command in self._cmd_list or command == self._send_cmd):
+            return
         LOGGER.debug(f"Adding command {command}")
+        self._cmd_list.append(command)
         await self._cmd_q.put(command)
 
     async def _get_command(self) -> Union[JablotronCommand, None]:
         if self._cmd_q.empty():
             return None
-        return await self._cmd_q.get()
+        cmd = await self._cmd_q.get()
+        if self._cmd_list:
+            self._cmd_list.pop(0)
+        self._send_cmd = cmd  # mark in flight for de-duplication
+        return cmd
 
     async def _forward_records(self, records: List[bytearray]) -> None:
         # #97: any data at all means the connection is alive; record the time so
@@ -775,7 +791,9 @@ class JablotronConnection:
                 if send_cmd is not None:
                     accepted = False
                     confirmed = False
-                    retries = 2
+                    # #153 (heifisch): more attempts so the detail query gets acked on flaky
+                    # comms; reconciliation only runs once a "Details" command is confirmed.
+                    retries = 10
 
                     while retries >= 0 and not (accepted and confirmed):
                         level = logging.INFO
@@ -821,6 +839,7 @@ class JablotronConnection:
                         retries -= 1
 
                     self._cmd_q.task_done()
+                    self._send_cmd = None
 
             except Exception:
                 LOGGER.exception("Unexpected error in packet loop")
@@ -1503,9 +1522,11 @@ class JA80CentralUnit(object):
         self._query.type = "button"
 
         self._active_devices = {}
+        self._active_devices_tmp = {}
         self._active_codes = {}
         self._codes = {}
         self._device_query_pending = False
+        self._force_query = False
         self._last_state = None
         self._mode = None
 
@@ -1859,18 +1880,12 @@ class JA80CentralUnit(object):
             return object.zone
 
     def _clear_triggers(self) -> None:
-        for device in self._devices.values():
-            # if self.system_mode == JA80CentralUnit.SYSTEM_MODE_UNSPLIT:
-            #    device.deactivate()
-            # else:
+        # #153 fix (heifisch): deactivate only currently-active sources; the persistent
+        # _active_devices/_active_codes registries stay populated for reconciliation.
+        for device in self._active_devices.values():
             device.active = False
-        self._active_devices.clear()
-        for code in self._codes.values():
-            # if self.system_mode == JA80CentralUnit.SYSTEM_MODE_UNSPLIT:
-            #    device.deactivate()
-            # else:
+        for code in self._active_codes.values():
             code.active = False
-        self._active_codes.clear()
 
     def _clear_source(self, source_id: bytes) -> None:
         source = self._get_source(source_id)
@@ -1890,6 +1905,7 @@ class JA80CentralUnit(object):
         source = self._get_source(source_id)
         if isinstance(source, JablotronDevice):
             self._activate_device(source)
+            self._activate_device_tmp(source)
         elif isinstance(source, JablotronCode):
             self._activate_code(source)
         else:
@@ -1914,12 +1930,15 @@ class JA80CentralUnit(object):
                 zone.code_activated(source)
 
     def _update_device(self):
-        for device in self._devices.values():
-            if device.device_id in self._active_devices:
+        # #153 fix (heifisch): reconcile against the set found in the current query round.
+        # A device in the persistent set but absent from this round (i.e. it closed) is
+        # turned off independently of other still-open detectors.
+        for device in self._active_devices.values():
+            if device.device_id in self._active_devices_tmp:
                 device.active = True
             else:
                 device.active = False
-        self._active_devices.clear()
+        self._active_devices_tmp.clear()
 
     def _activate_device(self, source):
         if isinstance(source, JablotronDevice):
@@ -1928,6 +1947,13 @@ class JA80CentralUnit(object):
             zone = self._get_zone_via_object(source)
             if not zone is None:
                 zone.device_activated(source)
+
+    def _activate_device_tmp(self, source):
+        # #153 fix (heifisch): record the device in the current query round so
+        # _update_device() can deactivate devices that are no longer reported.
+        if isinstance(source, JablotronDevice):
+            source.active = True
+            self._active_devices_tmp[source.device_id] = source
 
     def _fault_source(self, source_id: bytes) -> None:
         source = self._get_source(source_id)
@@ -2164,7 +2190,7 @@ class JA80CentralUnit(object):
             self.status = JA80CentralUnit.STATUS_NORMAL
             self._call_zones(function_name="disarm")
 
-            if activity == 0x00:  # and not self.led_alarm:
+            if activity == 0x00 and not self.led_alarm:
                 # clear active statuses
                 self._clear_triggers()
 
@@ -2291,8 +2317,13 @@ class JA80CentralUnit(object):
             # something is active
             if detail == 0x00:
                 # don't send query if we already have "triggered detector" displayed
-                if activity_name not in self.statustext.message or activity_name == self.statustext.message:
+                if (
+                    activity_name not in self.statustext.message
+                    or activity_name == self.statustext.message
+                    or self._force_query
+                ):
                     await self._send_device_query()
+                    self._force_query = False
                 else:
                     log = False
             else:
@@ -2322,6 +2353,9 @@ class JA80CentralUnit(object):
             else:
                 self._activate_source(detail)
                 self._confirm_device_query()
+            # #153 fix (heifisch): force a re-query on the next single-detector report so
+            # the active set is re-enumerated and closed detectors get reconciled off.
+            self._force_query = True
 
         else:
             warn = True

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,53 @@
+# jablotron80 starter test suite
+
+A small, runnable pytest suite for the `jablotron80` Home Assistant custom
+integration. It tests the integration's core logic **without installing Home
+Assistant** - `conftest.py` stubs the few `homeassistant.*` modules that
+`jablotron.py` (and the package `__init__.py`) import.
+
+## What is covered
+
+| File | What it protects |
+| --- | --- |
+| `test_reconciliation.py` | The **#153 per-sensor-close** logic: a closed detector turns off independently of another still-open one (`_activate_source` / `_update_device` on `JA80CentralUnit`). This is the most important test on the `fix/153-per-sensor-close` branch. |
+| `test_state.py` | `JablotronState` status-byte classification helpers (`is_armed_state`, `is_disarmed_state`, `is_alarm_state`, exit/entering delay, maintenance). |
+| `test_keypress.py` | `JablotronKeyPress.get_beep_option`, including upstream **issue #44** (`KeyError: 6` for the missing beep code), captured via `pytest.raises`. |
+
+## How the Home Assistant stub works
+
+`jablotron.py` imports `homeassistant.{core,const,config_entries}` at module top,
+and importing the `custom_components.jablotron80` package also runs its
+`__init__.py`, which pulls in the HA platform stack
+(`homeassistant.components.*`, `homeassistant.helpers.*`).
+
+`tests/conftest.py` inserts lightweight fake modules into `sys.modules` **before**
+the integration is imported, and adds the repo root to `sys.path` so that
+`import custom_components.jablotron80.jablotron` resolves as a package. No real
+Home Assistant install is required (or wanted).
+
+Setting a device's `.active` runs through a `@log_change` decorator that schedules
+`asyncio ... create_task(publish_updates())`. The `event_loop_for_setters` fixture
+installs a real current event loop so those setters are safe, and drains the
+no-op tasks at teardown.
+
+## Running
+
+From the repo root (`C:\dev\jablotron-upstream`):
+
+```powershell
+# one-time setup
+C:\Python314\python.exe -m venv .venv
+.\.venv\Scripts\python.exe -m pip install pytest pyserial crccheck
+
+# run the suite
+.\.venv\Scripts\python.exe -m pytest -v
+```
+
+Bash equivalent:
+
+```bash
+./.venv/Scripts/python.exe -m pytest -v
+```
+
+Home Assistant is deliberately **not** installed; the stubs in `conftest.py`
+provide everything the integration imports at module load time.

--- a/tests/test_command_dedup.py
+++ b/tests/test_command_dedup.py
@@ -1,0 +1,96 @@
+"""Tests for the narrowed command de-duplication (issue #153, maintainer feedback).
+
+Background
+----------
+The #153 port (heifisch) added de-duplication of queued commands in
+``JablotronConnection.add_command`` so that the automatic "Details" detail query
+does not pile up behind itself and block a disarm.
+
+The maintainer's concern: de-duplicating *every* command could silently drop a
+legitimate repeated command sequence (e.g. a user pressing disarm twice). The
+fix narrows the guard so that ONLY a "Details" command is de-duplicated;
+user/functional commands are always queued.
+
+These tests pin both halves of that contract:
+
+* two identical "Details" commands collapse to a single queued command, and
+* a non-"Details" command added twice is queued twice (never de-duplicated),
+
+while keeping the ``_cmd_q`` / ``_cmd_list`` bookkeeping balanced so that
+``_get_command``'s ``pop(0)`` stays consistent.
+"""
+
+import custom_components.jablotron80.jablotron as jablotron
+from custom_components.jablotron80.jablotron import (
+    JablotronCommand,
+    JablotronConnectionHID,
+)
+
+
+def _details_command() -> JablotronCommand:
+    """Build a fresh "Details" command equal to any other so-built one.
+
+    ``JablotronCommand`` is a dataclass, so two instances built with identical
+    fields compare equal - which is exactly what the de-dup guard relies on.
+    """
+    return JablotronCommand(name="Details", code=b"\x8e", accepted_prefix=b"\xa4\xff")
+
+
+def _user_command() -> JablotronCommand:
+    """Build a fresh non-"Details" (functional) command, e.g. a disarm keypress."""
+    return JablotronCommand(name="Disarm", code=b"\x8f", accepted_prefix=b"\xa0\xff")
+
+
+def test_repeated_details_command_is_deduplicated(event_loop_for_setters):
+    """Two identical "Details" queries collapse into a single queued command."""
+    loop = event_loop_for_setters
+    conn = JablotronConnectionHID("/dev/null")
+
+    loop.run_until_complete(conn.add_command(_details_command()))
+    loop.run_until_complete(conn.add_command(_details_command()))
+
+    # Only one survived: the second identical Details query was dropped.
+    assert conn._cmd_q.qsize() == 1
+    assert len(conn._cmd_list) == 1
+
+
+def test_repeated_user_command_is_not_deduplicated(event_loop_for_setters):
+    """A non-"Details" command added twice is queued twice (never de-duplicated).
+
+    This is the maintainer's requirement: a deliberately repeated functional
+    command (e.g. disarm pressed twice) must reach the panel both times.
+    """
+    loop = event_loop_for_setters
+    conn = JablotronConnectionHID("/dev/null")
+
+    loop.run_until_complete(conn.add_command(_user_command()))
+    loop.run_until_complete(conn.add_command(_user_command()))
+
+    # Both were queued - identical functional commands are NOT collapsed.
+    assert conn._cmd_q.qsize() == 2
+    assert len(conn._cmd_list) == 2
+
+
+def test_get_command_keeps_cmd_list_balanced_for_user_commands(event_loop_for_setters):
+    """Dequeuing pops exactly one ``_cmd_list`` entry per command, for any name.
+
+    The narrowed guard still appends every queued command to ``_cmd_list``, so
+    ``_get_command``'s ``pop(0)`` stays balanced even for non-"Details" commands.
+    """
+    loop = event_loop_for_setters
+    conn = JablotronConnectionHID("/dev/null")
+
+    loop.run_until_complete(conn.add_command(_user_command()))
+    loop.run_until_complete(conn.add_command(_user_command()))
+    assert len(conn._cmd_list) == 2
+
+    first = loop.run_until_complete(conn._get_command())
+    assert first is not None
+    # One dequeued -> exactly one popped from _cmd_list, and it is now in flight.
+    assert len(conn._cmd_list) == 1
+    assert conn._send_cmd is first
+
+    second = loop.run_until_complete(conn._get_command())
+    assert second is not None
+    assert len(conn._cmd_list) == 0
+    assert conn._cmd_q.empty()

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -1,0 +1,157 @@
+"""Tests for the per-sensor-close reconciliation logic (issue #153).
+
+This is the core protection for the ``fix/153-per-sensor-close`` branch.
+
+Background
+----------
+The JA-80 central unit reports the set of currently-active (triggered) detectors
+in each query round. The integration keeps two structures:
+
+* ``_active_devices``      - a *persistent* registry of every device ever seen
+                             active. It is never cleared, so it can reconcile.
+* ``_active_devices_tmp``  - the set of devices seen active *in the current
+                             query round*. It is rebuilt every round.
+
+``_update_device()`` reconciles: any device in the persistent registry that is
+*absent* from the current round (i.e. its detector closed) is set inactive,
+independently of other detectors that are still open. That independence is the
+#153 fix - a single closed detector must turn off on its own.
+
+Each device id used here is ``< 0x40`` so that ``_get_source`` resolves it to a
+``JablotronDevice`` (ids >= 0x40 are codes, see ``JA80CentralUnit._get_source``).
+"""
+
+import custom_components.jablotron80.jablotron as jablotron
+from custom_components.jablotron80.const import (
+    CABLE_MODEL,
+    CABLE_MODEL_JA82T,
+    CONFIGURATION_PASSWORD,
+    CONFIGURATION_SERIAL_PORT,
+)
+
+# Two arbitrary device ids, both < 0x40 so they resolve to devices, not codes.
+DEVICE_OPEN_THEN_CLOSED = 6
+DEVICE_STAYS_OPEN = 22
+
+
+def _build_unit():
+    """Construct a JA80CentralUnit with a dummy hass and the smallest config.
+
+    ``JA80CentralUnit.__init__`` requires only the cable model, the serial port
+    and the master password; every other key is optional (the constructor
+    tolerates their absence). The JA-82T cable model routes to the HID
+    connection class, whose constructor does NOT open the serial port - only
+    ``connect()`` (called from ``initialize()``, which we never call) does.
+    """
+    config = {
+        CABLE_MODEL: CABLE_MODEL_JA82T,
+        CONFIGURATION_SERIAL_PORT: "/dev/null",
+        CONFIGURATION_PASSWORD: "1234",
+    }
+    return jablotron.JA80CentralUnit(hass=None, config=config, options=None)
+
+
+def test_unit_constructs_with_minimal_config(event_loop_for_setters):
+    """Sanity check: the smallest config constructs and starts empty."""
+    unit = _build_unit()
+    assert unit._active_devices == {}
+    assert unit._active_devices_tmp == {}
+
+
+def test_round1_two_devices_active(event_loop_for_setters):
+    """Round 1: activating two devices puts both in tmp + persistent, active."""
+    unit = _build_unit()
+
+    unit._activate_source(DEVICE_OPEN_THEN_CLOSED)
+    unit._activate_source(DEVICE_STAYS_OPEN)
+
+    dev6 = unit.get_device(DEVICE_OPEN_THEN_CLOSED)
+    dev22 = unit.get_device(DEVICE_STAYS_OPEN)
+
+    # Both devices report active immediately after activation.
+    assert dev6.active is True
+    assert dev22.active is True
+
+    # Both are tracked in the per-round (tmp) set and the persistent registry.
+    assert DEVICE_OPEN_THEN_CLOSED in unit._active_devices_tmp
+    assert DEVICE_STAYS_OPEN in unit._active_devices_tmp
+    assert DEVICE_OPEN_THEN_CLOSED in unit._active_devices
+    assert DEVICE_STAYS_OPEN in unit._active_devices
+
+
+def test_round1_update_keeps_both_active(event_loop_for_setters):
+    """Round 1 reconcile: tmp is cleared, both devices stay active.
+
+    Because both devices were reported in this round, ``_update_device`` must
+    keep both active and empty the per-round set.
+    """
+    unit = _build_unit()
+
+    unit._activate_source(DEVICE_OPEN_THEN_CLOSED)
+    unit._activate_source(DEVICE_STAYS_OPEN)
+    unit._update_device()
+
+    dev6 = unit.get_device(DEVICE_OPEN_THEN_CLOSED)
+    dev22 = unit.get_device(DEVICE_STAYS_OPEN)
+
+    assert unit._active_devices_tmp == {}
+    assert dev6.active is True
+    assert dev22.active is True
+
+
+def test_per_sensor_close_closes_only_the_absent_device(event_loop_for_setters):
+    """The #153 proof: a closed detector turns off independently.
+
+    Round 1: devices 6 and 22 are both open.
+    Round 2: only device 22 is reported (device 6 closed). After reconciliation,
+    device 6 must be inactive while device 22 stays active.
+
+    Contrast with the pre-fix behaviour: the old code cleared/kept triggers as a
+    group, so a single still-open detector (22) could keep a closed detector (6)
+    erroneously "active", or clearing one could wrongly clear the other. This
+    test fails on that regression and passes on the per-sensor-close fix.
+    """
+    unit = _build_unit()
+
+    # Round 1 - both detectors open.
+    unit._activate_source(DEVICE_OPEN_THEN_CLOSED)
+    unit._activate_source(DEVICE_STAYS_OPEN)
+    unit._update_device()
+
+    dev6 = unit.get_device(DEVICE_OPEN_THEN_CLOSED)
+    dev22 = unit.get_device(DEVICE_STAYS_OPEN)
+    assert dev6.active is True
+    assert dev22.active is True
+
+    # Round 2 - only device 22 is reported; device 6 has closed.
+    unit._activate_source(DEVICE_STAYS_OPEN)
+    unit._update_device()
+
+    # The closed detector turns off on its own ...
+    assert dev6.active is False
+    # ... while the still-open detector remains active.
+    assert dev22.active is True
+
+    # Device 6 stays in the persistent registry so it can reconcile again later.
+    assert DEVICE_OPEN_THEN_CLOSED in unit._active_devices
+    assert DEVICE_STAYS_OPEN in unit._active_devices
+
+
+def test_reopen_after_close_reactivates(event_loop_for_setters):
+    """A detail check: a device can close and then re-open across rounds."""
+    unit = _build_unit()
+    dev6 = unit.get_device(DEVICE_OPEN_THEN_CLOSED)
+
+    # Open, reconcile -> active.
+    unit._activate_source(DEVICE_OPEN_THEN_CLOSED)
+    unit._update_device()
+    assert dev6.active is True
+
+    # Absent next round -> closed.
+    unit._update_device()
+    assert dev6.active is False
+
+    # Reported again -> active once more.
+    unit._activate_source(DEVICE_OPEN_THEN_CLOSED)
+    unit._update_device()
+    assert dev6.active is True

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,87 @@
+"""Tests for the ``JablotronState`` status-byte classification helpers.
+
+``JablotronState`` (in jablotron.py) maps raw status bytes from the central unit
+to logical states. The helpers tested here are pure static methods over the
+constants defined in the same class, so they are easy to assert against without
+constructing the unit.
+
+All expected values below are taken directly from the constants in
+``JablotronState`` - they are not guessed.
+"""
+
+import custom_components.jablotron80.jablotron as jablotron
+
+JablotronState = jablotron.JablotronState
+
+
+# ---------------------------------------------------------------------------
+# is_armed_state  (membership in STATES_ARMED)
+# ---------------------------------------------------------------------------
+def test_is_armed_state_for_armed_bytes():
+    # 0x43 = ARMED_ABC (unsplit/partial), 0x61 = ARMED_SPLIT_A.
+    assert JablotronState.is_armed_state(JablotronState.ARMED_ABC) is True
+    assert JablotronState.is_armed_state(JablotronState.ARMED_A) is True
+    assert JablotronState.is_armed_state(JablotronState.ARMED_SPLIT_A) is True
+
+
+def test_is_armed_state_false_for_disarmed():
+    # A disarmed byte must not classify as armed.
+    assert JablotronState.is_armed_state(JablotronState.DISARMED) is False
+
+
+# ---------------------------------------------------------------------------
+# is_disarmed_state  (membership in STATES_DISARMED)
+# ---------------------------------------------------------------------------
+def test_is_disarmed_state_for_disarmed_bytes():
+    # 0x40 unsplit/partial disarmed, 0x60 split disarmed.
+    assert JablotronState.is_disarmed_state(JablotronState.DISARMED) is True
+    assert JablotronState.is_disarmed_state(JablotronState.DISARMED_SPLIT) is True
+
+
+def test_is_disarmed_state_false_for_armed():
+    assert JablotronState.is_disarmed_state(JablotronState.ARMED_ABC) is False
+
+
+# ---------------------------------------------------------------------------
+# is_alarm_state  (membership in STATES_ALARM)
+# ---------------------------------------------------------------------------
+def test_is_alarm_state_for_alarm_bytes():
+    # 0x45 ALARM_A, 0x44 ALARM_WITHOUT_ARMING, 0x67 ALARM_C_SPLIT.
+    assert JablotronState.is_alarm_state(JablotronState.ALARM_A) is True
+    assert JablotronState.is_alarm_state(JablotronState.ALARM_WITHOUT_ARMING) is True
+    assert JablotronState.is_alarm_state(JablotronState.ALARM_C_SPLIT) is True
+
+
+def test_is_alarm_state_false_for_non_alarm():
+    assert JablotronState.is_alarm_state(JablotronState.DISARMED) is False
+    assert JablotronState.is_alarm_state(JablotronState.ARMED_ABC) is False
+
+
+# ---------------------------------------------------------------------------
+# exit-delay and entering-delay classification (membership lists)
+# ---------------------------------------------------------------------------
+def test_is_exit_delay_state():
+    # 0x53 EXIT_DELAY_ABC, 0x71 EXIT_DELAY_SPLIT_A.
+    assert JablotronState.is_exit_delay_state(JablotronState.EXIT_DELAY_ABC) is True
+    assert JablotronState.is_exit_delay_state(JablotronState.EXIT_DELAY_SPLIT_A) is True
+    assert JablotronState.is_exit_delay_state(JablotronState.DISARMED) is False
+
+
+def test_is_entering_delay_state():
+    # 0x49 ARMED_ENTRY_DELAY_A, 0x4B ARMED_ENTRY_DELAY_ABC.
+    assert JablotronState.is_entering_delay_state(JablotronState.ARMED_ENTRY_DELAY_A) is True
+    assert JablotronState.is_entering_delay_state(JablotronState.ARMED_ENTRY_DELAY_ABC) is True
+    assert JablotronState.is_entering_delay_state(JablotronState.DISARMED) is False
+
+
+# ---------------------------------------------------------------------------
+# maintenance classification (bitwise: MAINTENANCE set AND DISARMED bit clear)
+# ---------------------------------------------------------------------------
+def test_is_maintenance_state_true_for_maintenance_byte():
+    # MAINTENANCE = 0x20: 0x20 & 0x20 -> truthy, 0x20 & 0x40 -> 0 (not disarmed).
+    assert bool(JablotronState.is_maintenance_state(JablotronState.MAINTENANCE)) is True
+
+
+def test_is_maintenance_state_false_for_disarmed_byte():
+    # DISARMED = 0x40: the DISARMED bit is set, so it is explicitly not maintenance.
+    assert bool(JablotronState.is_maintenance_state(JablotronState.DISARMED)) is False


### PR DESCRIPTION
## Problem

When multiple wireless sensors are active at once, the integration spams the keypad with detail ("?") queries and arm/disarm becomes unreliable:

- #167 - wireless keypad spammed when multiple wireless sensors are active
- #168 - not able to arm/disarm reliably when multiple wireless sensors are active

It also leaves a closed door/window sensor stuck "on" until *all* sensors are closed (the long-standing #153 behaviour).

## Root cause

`_process_state` requests a detail query on (almost) every "triggered detector" packet, and these queries pile up in the command queue, drowning out arm/disarm key presses. The per-sensor reconciliation (`_update_device`) only runs once a "Details" query is acknowledged, which on flaky links rarely happens, so closed sensors never get cleared.

## Changes

Ports @heifisch's community-validated #153 fix to the current (async) code base and adds queue de-duplication for #167/#168:

- **Two-set reconciliation**: `_active_devices` (persistent registry) + `_active_devices_tmp` (devices seen in the current query round). `_update_device()` deactivates a device absent from the current round, so a closed detector turns off independently of other still-open detectors (#153).
- **`_force_query`**: after a multi-detector (`0x16`) report, force a re-query on the next single-detector (`0x10`) report so the active set is re-enumerated.
- **Command de-duplication** on `JablotronConnection` (`_cmd_list` / `_send_cmd`): skip a command already queued or in flight, so repeated detail queries don't pile up and block disarm (#167/#168). Adapted from heifisch's sync version to `asyncio.Queue`.
- **retries 2 -> 10** in the send loop so the detail query keeps trying until acked on flaky comms (heifisch).

## Credits

- @heifisch - original `update_devices` approach in #153.
- @ondrejmirtes - located the query-cycling branches for #167.

## Testing / scope

> Tested on a single configuration: wireless 868 MHz sensors, JA-82T PC interface (USB-HID), no PGX/PGY, HA Core 2026.5.3.

- **Per-sensor close verified live**: opening one window turns its sensor `on`; closing it turns *that* sensor `off` while other open sensors stay `on` (two open/close cycles).
- **Arm/disarm with multiple active sensors (#168)**: verification in progress on the reporter's hardware.
- **Automated tests included** (`tests/`): a lightweight pytest suite that stubs the Home Assistant modules so the protocol/reconciliation logic runs with just `pytest + pyserial + crccheck` (no `homeassistant` install). It includes a reconciliation test that guards this fix (a closed detector deactivates independently of other still-open ones), `JablotronState` classification tests, and a `get_beep_option` test that also captures the `KeyError` from #44 as a regression marker. The repo previously had no tests; this is a starter suite.

Feedback very welcome, especially from setups with wired sensors or PGX/PGY, since those paths are untested here. Opened as a draft until the arm/disarm check is complete.
