### PR TITLE
Mark entities unavailable when no data is flowing from the panel (#97)

### DIFF
--- a/custom_components/jablotron80/alarm_control_panel.py
+++ b/custom_components/jablotron80/alarm_control_panel.py
@@ -291,7 +291,10 @@ class Jablotron80AlarmControl(JablotronEntity, AlarmControlPanelEntity):
         # return self._cu.led_power
         # when running on battery power the led in off (well flashing) and the sytem is still working see issue#85
         # we should enhance this to be based on the data flowing on the serial line
-        return True
+        # #97: availability now follows the serial data flow. connection_alive is
+        # True only while data has arrived recently; the watchdog refreshes the
+        # zones this panel is registered on, so this flips with the connection.
+        return self._cu.connection_alive
 
     @property
     def device_info(self) -> Optional[Dict[str, Any]]:

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -28,7 +28,6 @@ from homeassistant.core import HomeAssistant
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
-
 if __name__ == "__main__":
     from const import (
         CONFIGURATION_SERIAL_PORT,

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -666,6 +666,13 @@ class JablotronConnection:
         self._connection = None
         self._messages = asyncio.Event()
         self.update_devices = False
+        # #97: track when we last received data so a watchdog can detect a
+        # silently dead connection (the HID read blocks without a timeout).
+        self._last_data_time = time.monotonic()
+
+    @property
+    def seconds_since_last_data(self) -> float:
+        return time.monotonic() - self._last_data_time
 
     def get_record(self) -> List[bytearray]:
         records = []
@@ -709,6 +716,10 @@ class JablotronConnection:
         return await self._cmd_q.get()
 
     async def _forward_records(self, records: List[bytearray]) -> None:
+        # #97: any data at all means the connection is alive; record the time so
+        # the central-unit watchdog can mark entities unavailable when it stops.
+        if records:
+            self._last_data_time = time.monotonic()
         await self._output_q.put(records)
         # self._log_detail(f"Forwarding {len(records)} records")
         self._messages.set()
@@ -1384,6 +1395,12 @@ class JA80CentralUnit(object):
 
     _ZONE_UNSPLIT = 1
 
+    # #97: if no data has arrived from the panel for this long the connection is
+    # considered stale and all entities are marked unavailable. The watchdog
+    # checks at the (shorter) interval below.
+    CONNECTION_DATA_TIMEOUT_SECONDS = 30
+    CONNECTION_WATCHDOG_INTERVAL_SECONDS = 10
+
     def _create_led(self, id_: int, name: str, type: str) -> JablotronLed:
         led = JablotronLed(id_)
         led.name = f"{CENTRAL_UNIT_MODEL} {name}"
@@ -1402,6 +1419,9 @@ class JA80CentralUnit(object):
         self._options: Dict[str, Any] = options
         self._settings = JablotronSettings()
         self._connection = JablotronConnection.factory(config[CABLE_MODEL], config[CONFIGURATION_SERIAL_PORT])
+        # #97: tracks the last published connection-alive state so the watchdog
+        # only refreshes/logs on an edge (alive -> stale or stale -> alive).
+        self._connection_was_alive = True
         try:
             self._max_number_of_wired_devices = config[CONFIGURATION_NUMBER_OF_WIRED_DEVICES]
         except KeyError:
@@ -1506,6 +1526,53 @@ class JA80CentralUnit(object):
         except:
             pass
 
+    @property
+    def connection_alive(self) -> bool:
+        # #97: the connection is alive only if data has arrived recently. The
+        # HID read blocks indefinitely, so a dead link produces no exception -
+        # silence is the only signal we have.
+        return self._connection.seconds_since_last_data < self.CONNECTION_DATA_TIMEOUT_SECONDS
+
+    async def _refresh_all_entities(self) -> None:
+        # #97: re-publish every entity-backed object so Home Assistant re-reads
+        # `available` (which now depends on connection_alive). The objects are
+        # @dataclass instances and therefore unhashable, so we de-duplicate by
+        # identity via a dict keyed on id(); the central device in particular
+        # appears both as `central_device` and as `_devices[0]`.
+        candidates = [
+            self.central_device,
+            *self._devices.values(),
+            *self._zones.values(),
+            *self._codes.values(),
+            *self._leds.values(),
+            self._statustext,
+            self._alert,
+            self._query,
+        ]
+        objects = {id(obj): obj for obj in candidates if obj is not None}
+        for obj in objects.values():
+            try:
+                await obj.publish_updates()
+            except Exception as ex:
+                LOGGER.debug(f"Failed to refresh entity {obj}: {ex}")
+
+    async def _connection_watchdog(self) -> None:
+        # #97: periodically check whether the panel is still talking to us and,
+        # on a transition, refresh all entities so their availability flips.
+        while not self._stop.is_set():
+            await asyncio.sleep(self.CONNECTION_WATCHDOG_INTERVAL_SECONDS)
+            alive = self.connection_alive
+            if alive != self._connection_was_alive:
+                self._connection_was_alive = alive
+                if alive:
+                    LOGGER.info("Connection to JA80 recovered, marking entities available")
+                else:
+                    LOGGER.warning(
+                        "No data from JA80 for over "
+                        f"{self.CONNECTION_DATA_TIMEOUT_SECONDS}s, marking entities unavailable"
+                    )
+                await self._refresh_all_entities()
+
     async def initialize(self) -> None:
         global _loop
 
@@ -1519,6 +1586,7 @@ class JA80CentralUnit(object):
         _loop = asyncio.get_event_loop()
         _loop.create_task(self.processing_loop())
         asyncio.create_task(self._connection.read_send_packet_loop())
+        asyncio.create_task(self._connection_watchdog())
         await asyncio.wait_for(self._havestate.wait(), 20)
         LOGGER.info(f"initialization done.")
 

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -16,6 +16,11 @@ expected_warning_level = logging.WARN
 verbose_connection_logging = False
 _loop = None  # global variable to store event loop
 
+# #165/#97: how long the packet loop waits before retrying after a failed
+# reconnect, so a dropped USB/serial link is retried (not abandoned) and the
+# integration recovers automatically once the device returns.
+RECONNECT_BACKOFF_SECONDS = 5
+
 
 from typing import Any, Dict, Optional, Union, Callable
 from homeassistant import config_entries
@@ -694,11 +699,14 @@ class JablotronConnection:
         else:
             LOGGER.info("No need to disconnect; not connected")
 
-    async def reconnect(self):
+    async def reconnect(self) -> bool:
         LOGGER.warning("connection failed, reconnecting")
         await asyncio.sleep(1)
         await self.disconnect()
         await self.connect()
+        # #165/#97: report whether the reconnect actually succeeded so callers
+        # (the packet loop) can back off and retry instead of assuming success.
+        return self.is_connected()
 
     def shutdown(self) -> None:
         self._stop.set()
@@ -746,8 +754,17 @@ class JablotronConnection:
         while not self._stop.is_set() or not self._cmd_q.empty():
             try:
                 if not self.is_connected():
-                    LOGGER.error("Not connected to JA80, abort")
-                    return
+                    # #165/#97: do NOT exit the loop on a transient disconnect.
+                    # Keep trying to reconnect with backoff so the integration
+                    # recovers automatically when the device returns. `continue`
+                    # re-enters the while loop (re-checking the stop condition and
+                    # is_connected), and crucially skips the _read_data /
+                    # _forward_records(records) path below so `records` is never
+                    # referenced before assignment on this branch.
+                    LOGGER.warning("Not connected to JA80, attempting to reconnect")
+                    if not await self.reconnect():
+                        await asyncio.sleep(RECONNECT_BACKOFF_SECONDS)
+                    continue
 
                 try:
                     records = await self._read_data()
@@ -828,11 +845,18 @@ class JablotronConnectionHID(JablotronConnection):
         LOGGER.info(f"Connecting to JA80 via HID using {self._device}...")
         loop = asyncio.get_running_loop()
 
-        self._connection = await loop.run_in_executor(None, open, self._device, "w+b", 0)
+        # #165/#97: tolerate a failed open so the reconnect loop can keep
+        # retrying instead of the packet loop dying. On failure we leave
+        # _connection as None (is_connected() stays False) and return.
+        try:
+            self._connection = await loop.run_in_executor(None, open, self._device, "w+b", 0)
 
-        LOGGER.debug("Sending startup message")
-        await asyncio.to_thread(self._connection.write, b"\x00\x00\x01\x01")
-        LOGGER.debug("Successfully sent startup message")
+            LOGGER.debug("Sending startup message")
+            await asyncio.to_thread(self._connection.write, b"\x00\x00\x01\x01")
+            LOGGER.debug("Successfully sent startup message")
+        except OSError as ex:
+            LOGGER.warning(f"Failed to connect to JA80 ({ex})")
+            self._connection = None
 
     def _get_cmd(self, code: bytes) -> bytes:
         return b"\x00\x02\x01" + code
@@ -899,7 +923,14 @@ class JablotronConnectionSerial(JablotronConnection):
                 elif "unreachable" in ex_msg:
                     LOGGER.info("Remote serial host is currently unreachable, retrying")
                 else:
-                    raise
+                    # #165/#97: tolerate an unexpected open failure instead of
+                    # raising, so the packet loop's reconnect-with-backoff keeps
+                    # retrying. Leave _connection None (is_connected() False) and
+                    # return; the in-loop retries above still cover the known
+                    # transient remote errors.
+                    LOGGER.warning(f"Failed to connect to JA80 ({ex})")
+                    self._connection = None
+                    return
 
     async def _read_data(self, max_package_sections: int = 15) -> List[bytearray]:
         ret_val = []
@@ -1548,6 +1579,7 @@ class JA80CentralUnit(object):
             self._statustext,
             self._alert,
             self._query,
+            self._rf_level,
         ]
         objects = {id(obj): obj for obj in candidates if obj is not None}
         for obj in objects.values():

--- a/custom_components/jablotron80/jablotronHA.py
+++ b/custom_components/jablotron80/jablotronHA.py
@@ -32,10 +32,11 @@ class JablotronEntity(Entity):
     def available(self) -> bool:
         # return self._cu.led_power
 
-        if hasattr(self._object, "available"):
-            return self._object.available
-        else:
-            return True
+        # #97: an entity is available only while the central unit's connection
+        # is alive AND the underlying object reports itself available.
+        return self._cu.connection_alive and (
+            self._object.available if hasattr(self._object, "available") else True
+        )
 
     @property
     def device_info(self) -> Optional[Dict[str, Any]]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,171 @@
+"""Shared pytest fixtures and Home Assistant stubs for the jablotron80 tests.
+
+The integration's ``jablotron.py`` imports Home Assistant at module top:
+
+    from homeassistant import config_entries
+    from homeassistant.core import HomeAssistant
+    from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+
+Home Assistant is a very heavy dependency and is NOT installed in this test
+environment (by design - the task forbids installing it). Instead we insert
+lightweight fake modules into ``sys.modules`` BEFORE the integration is imported,
+so those imports resolve against our stubs.
+
+We also put the repo root on ``sys.path`` so that
+``import custom_components.jablotron80.jablotron`` resolves as a package.
+"""
+
+import asyncio
+import os
+import sys
+import types
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# 1. Make the repo root importable as the parent of ``custom_components``.
+# ---------------------------------------------------------------------------
+# conftest.py lives in <repo>/tests/, so the repo root is one level up.
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+
+# ---------------------------------------------------------------------------
+# 2. Install fake ``homeassistant`` modules into sys.modules.
+# ---------------------------------------------------------------------------
+def _install_homeassistant_stubs() -> None:
+    """Insert minimal fake homeassistant modules so the imports succeed.
+
+    Only the symbols actually imported by jablotron.py (and, defensively, by
+    const.py / errors.py) are provided. Everything is a trivial dummy: the
+    tests never drive real Home Assistant behaviour.
+    """
+    if "homeassistant" in sys.modules:
+        return
+
+    # Top-level package.
+    ha = types.ModuleType("homeassistant")
+    ha.__path__ = []  # mark as a package so submodule imports are allowed
+
+    # homeassistant.core  ->  HomeAssistant (a dummy class is enough)
+    ha_core = types.ModuleType("homeassistant.core")
+
+    class HomeAssistant:  # noqa: D401 - dummy stand-in
+        """Dummy HomeAssistant stand-in used only for type references."""
+
+    ha_core.HomeAssistant = HomeAssistant
+
+    # homeassistant.const  ->  EVENT_HOMEASSISTANT_STOP (a dummy string)
+    ha_const = types.ModuleType("homeassistant.const")
+    ha_const.EVENT_HOMEASSISTANT_STOP = "homeassistant_stop"
+
+    # homeassistant.config_entries  ->  empty module object is sufficient
+    ha_config_entries = types.ModuleType("homeassistant.config_entries")
+
+    # config_entries.ConfigEntry is referenced as a type hint in the package
+    # __init__.py; a bare class is enough.
+    class ConfigEntry:  # noqa: D401 - dummy stand-in
+        """Dummy ConfigEntry stand-in used only for type references."""
+
+    ha_config_entries.ConfigEntry = ConfigEntry
+
+    # homeassistant.exceptions  ->  HomeAssistantError (errors.py subclasses it)
+    ha_exceptions = types.ModuleType("homeassistant.exceptions")
+
+    class HomeAssistantError(Exception):
+        """Dummy base error matching homeassistant.exceptions.HomeAssistantError."""
+
+    ha_exceptions.HomeAssistantError = HomeAssistantError
+
+    # -- The integration package __init__.py imports the full HA platform stack.
+    # Importing `custom_components.jablotron80.jablotron` runs that __init__.py,
+    # so we must stub everything it pulls in too. Each platform module only needs
+    # a DOMAIN string.
+    ha_components = types.ModuleType("homeassistant.components")
+    ha_components.__path__ = []
+
+    def _platform_module(name: str, domain: str) -> types.ModuleType:
+        mod = types.ModuleType(f"homeassistant.components.{name}")
+        mod.DOMAIN = domain
+        return mod
+
+    ha_comp_alarm = _platform_module("alarm_control_panel", "alarm_control_panel")
+    ha_comp_binary = _platform_module("binary_sensor", "binary_sensor")
+    ha_comp_sensor = _platform_module("sensor", "sensor")
+    ha_comp_button = _platform_module("button", "button")
+
+    # homeassistant.helpers with device_registry and config_validation.
+    ha_helpers = types.ModuleType("homeassistant.helpers")
+    ha_helpers.__path__ = []
+
+    ha_dr = types.ModuleType("homeassistant.helpers.device_registry")
+
+    def _async_get(_hass):
+        return None
+
+    ha_dr.async_get = _async_get
+
+    ha_cv = types.ModuleType("homeassistant.helpers.config_validation")
+
+    def _config_entry_only_config_schema(_domain):
+        # The package __init__.py calls this at import time; return a no-op.
+        return lambda value: value
+
+    ha_cv.config_entry_only_config_schema = _config_entry_only_config_schema
+
+    ha_helpers.device_registry = ha_dr
+    ha_helpers.config_validation = ha_cv
+
+    sys.modules["homeassistant"] = ha
+    sys.modules["homeassistant.core"] = ha_core
+    sys.modules["homeassistant.const"] = ha_const
+    sys.modules["homeassistant.config_entries"] = ha_config_entries
+    sys.modules["homeassistant.exceptions"] = ha_exceptions
+    sys.modules["homeassistant.components"] = ha_components
+    sys.modules["homeassistant.components.alarm_control_panel"] = ha_comp_alarm
+    sys.modules["homeassistant.components.binary_sensor"] = ha_comp_binary
+    sys.modules["homeassistant.components.sensor"] = ha_comp_sensor
+    sys.modules["homeassistant.components.button"] = ha_comp_button
+    sys.modules["homeassistant.helpers"] = ha_helpers
+    sys.modules["homeassistant.helpers.device_registry"] = ha_dr
+    sys.modules["homeassistant.helpers.config_validation"] = ha_cv
+
+
+_install_homeassistant_stubs()
+
+
+# ---------------------------------------------------------------------------
+# 3. Event-loop fixture.
+# ---------------------------------------------------------------------------
+# Setting a JablotronCommon ``.active`` to a *new* value runs through the
+# ``@log_change`` decorator. When the value actually changes, log_change calls
+#     asyncio.get_event_loop().create_task(obj.publish_updates())
+# Under Python 3.12+ ``asyncio.get_event_loop()`` raises if there is no current
+# event loop set for the thread and none is running. We therefore install a
+# real loop as the current loop for the duration of each test so those setters
+# are safe. ``publish_updates`` is a no-op coroutine when no callbacks are
+# registered (the test devices have none), so the scheduled task is harmless.
+@pytest.fixture
+def event_loop_for_setters():
+    """Provide a real current event loop so ``.active`` setters are safe."""
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        yield loop
+    finally:
+        # log_change schedules publish_updates() coroutine tasks on this loop
+        # whenever a tracked attribute changes. The loop never .run()s during a
+        # test, so those tasks are still pending at teardown. Run the loop once
+        # to completion to let the (no-op) coroutines finish cleanly; otherwise
+        # asyncio emits "Task was destroyed but it is pending" warnings.
+        try:
+            pending = asyncio.all_tasks(loop)
+            if pending:
+                loop.run_until_complete(
+                    asyncio.gather(*pending, return_exceptions=True)
+                )
+        except Exception:
+            pass
+        loop.close()
+        asyncio.set_event_loop(None)

--- a/tests/test_connection_availability.py
+++ b/tests/test_connection_availability.py
@@ -1,0 +1,141 @@
+"""Tests for the stale-data / connection-watchdog logic (issue #97).
+
+Background
+----------
+``JablotronConnectionHID._read_data`` blocks waiting for serial data and never
+times out, so a dead link produces no exception - it just goes silent. Issue #97
+adds a watchdog: the connection records ``_last_data_time`` whenever non-empty
+records are forwarded, exposes ``seconds_since_last_data``, and the central unit
+derives ``connection_alive`` from it. When the link goes stale the watchdog
+re-publishes every entity so Home Assistant flips them to "unavailable".
+
+These tests exercise the connection and central-unit logic directly. They do NOT
+instantiate Home Assistant ``Entity`` subclasses (those need the real HA platform
+classes, which are stubbed away here).
+
+The async helpers (``_forward_records``, ``_refresh_all_entities``) are driven
+via the ``event_loop_for_setters`` fixture from conftest, which installs a real
+current event loop for the duration of the test.
+"""
+
+import time
+
+import custom_components.jablotron80.jablotron as jablotron
+from custom_components.jablotron80.const import (
+    CABLE_MODEL,
+    CABLE_MODEL_JA82T,
+    CONFIGURATION_PASSWORD,
+    CONFIGURATION_SERIAL_PORT,
+)
+
+
+def _build_unit():
+    """Construct a JA80CentralUnit with the smallest valid config.
+
+    Mirrors ``tests/test_reconciliation.py``: the JA-82T cable model routes to
+    the HID connection class, whose constructor does NOT open the serial port,
+    so this is safe without any hardware.
+    """
+    config = {
+        CABLE_MODEL: CABLE_MODEL_JA82T,
+        CONFIGURATION_SERIAL_PORT: "/dev/null",
+        CONFIGURATION_PASSWORD: "1234",
+    }
+    return jablotron.JA80CentralUnit(hass=None, config=config, options=None)
+
+
+# ---------------------------------------------------------------------------
+# JablotronConnection.seconds_since_last_data
+# ---------------------------------------------------------------------------
+def test_seconds_since_last_data_starts_sane(event_loop_for_setters):
+    """A freshly constructed connection has just "seen" data, so the elapsed
+    time is small and non-negative."""
+    unit = _build_unit()
+    elapsed = unit._connection.seconds_since_last_data
+    assert elapsed >= 0.0
+    assert elapsed < 5.0
+
+
+def test_seconds_since_last_data_grows_when_backdated(event_loop_for_setters):
+    """Backdating ``_last_data_time`` increases the reported elapsed time."""
+    unit = _build_unit()
+    unit._connection._last_data_time = time.monotonic() - 100
+    elapsed = unit._connection.seconds_since_last_data
+    assert elapsed >= 100.0
+    assert elapsed < 200.0  # sanity upper bound
+
+
+# ---------------------------------------------------------------------------
+# JA80CentralUnit.connection_alive
+# ---------------------------------------------------------------------------
+def test_connection_alive_true_when_recent(event_loop_for_setters):
+    """With recent data the connection counts as alive."""
+    unit = _build_unit()
+    unit._connection._last_data_time = time.monotonic()
+    assert unit.connection_alive is True
+
+
+def test_connection_alive_false_when_stale(event_loop_for_setters):
+    """Backdating well past the timeout makes the connection count as dead."""
+    unit = _build_unit()
+    unit._connection._last_data_time = time.monotonic() - 100
+    assert unit.connection_alive is False
+
+
+def test_connection_alive_boundary_within_timeout(event_loop_for_setters):
+    """Just inside the timeout window still counts as alive."""
+    unit = _build_unit()
+    # Half the configured timeout ago -> still alive.
+    unit._connection._last_data_time = (
+        time.monotonic() - unit.CONNECTION_DATA_TIMEOUT_SECONDS / 2
+    )
+    assert unit.connection_alive is True
+
+
+# ---------------------------------------------------------------------------
+# JablotronConnection._forward_records updates _last_data_time
+# ---------------------------------------------------------------------------
+def test_forward_records_updates_timestamp_for_nonempty(event_loop_for_setters):
+    """A non-empty record batch refreshes ``_last_data_time``."""
+    unit = _build_unit()
+    conn = unit._connection
+    # Make the connection look stale first.
+    conn._last_data_time = time.monotonic() - 100
+    before = conn._last_data_time
+
+    event_loop_for_setters.run_until_complete(
+        conn._forward_records([bytearray(b"\x01\xff")])
+    )
+
+    after = conn._last_data_time
+    assert after > before
+    # And it is now effectively "recent".
+    assert conn.seconds_since_last_data < 5.0
+
+
+def test_forward_records_leaves_timestamp_for_empty(event_loop_for_setters):
+    """An empty record batch must NOT refresh ``_last_data_time`` - silence on
+    the wire is exactly the stale condition the watchdog detects."""
+    unit = _build_unit()
+    conn = unit._connection
+    conn._last_data_time = time.monotonic() - 100
+    before = conn._last_data_time
+
+    event_loop_for_setters.run_until_complete(conn._forward_records([]))
+
+    after = conn._last_data_time
+    assert after == before
+
+
+# ---------------------------------------------------------------------------
+# _refresh_all_entities is robust and de-duplicated
+# ---------------------------------------------------------------------------
+def test_refresh_all_entities_runs_without_error(event_loop_for_setters):
+    """Refreshing all entity-backed objects must not raise even though none of
+    the test objects has callbacks registered (publish_updates is a no-op).
+
+    The central device is de-duplicated (it is both ``central_device`` and
+    ``_devices[0]``) by the set, so it is only refreshed once.
+    """
+    unit = _build_unit()
+    event_loop_for_setters.run_until_complete(unit._refresh_all_entities())

--- a/tests/test_reconnect.py
+++ b/tests/test_reconnect.py
@@ -1,0 +1,175 @@
+"""Tests for the auto-reconnect / connect-failure-tolerance logic (#165, #97).
+
+Background
+----------
+When the USB/serial link drops, the integration must NOT die. Previously:
+
+* ``JablotronConnectionHID.connect()`` raised if ``open()`` failed, and
+* ``read_send_packet_loop`` returned (exited) the moment ``is_connected()`` was
+  False.
+
+Together that meant nothing ever reconnected, even after the device returned.
+
+The fix makes ``connect()`` tolerate a failed ``open()`` (leaving the connection
+``None`` instead of raising) and makes ``reconnect()`` report success as a bool
+so the packet loop can back off and retry. These tests exercise that contract
+directly, without any real hardware and without Home Assistant ``Entity``
+instances.
+
+The async helpers are driven via the ``event_loop_for_setters`` fixture from
+conftest, which installs a real current event loop for the test.
+"""
+
+import builtins
+
+import pytest
+
+import custom_components.jablotron80.jablotron as jablotron
+from custom_components.jablotron80.const import (
+    CABLE_MODEL,
+    CABLE_MODEL_JA82T,
+    CONFIGURATION_PASSWORD,
+    CONFIGURATION_SERIAL_PORT,
+)
+
+
+def _build_unit():
+    """Construct a JA80CentralUnit with the smallest valid (HID) config.
+
+    The JA-82T cable model routes to the HID connection class, whose constructor
+    does NOT open the serial port, so this is safe without hardware.
+    """
+    config = {
+        CABLE_MODEL: CABLE_MODEL_JA82T,
+        CONFIGURATION_SERIAL_PORT: "/dev/null",
+        CONFIGURATION_PASSWORD: "1234",
+    }
+    return jablotron.JA80CentralUnit(hass=None, config=config, options=None)
+
+
+# ---------------------------------------------------------------------------
+# connect() tolerates a failed open
+# ---------------------------------------------------------------------------
+def test_hid_connect_nonexistent_device_does_not_raise(event_loop_for_setters):
+    """Opening a device that does not exist must NOT raise; the connection is
+    simply left disconnected so the reconnect loop can keep retrying."""
+    conn = jablotron.JablotronConnectionHID("/nonexistent/device/path")
+
+    # Must not raise.
+    event_loop_for_setters.run_until_complete(conn.connect())
+
+    assert conn.is_connected() is False
+
+
+def test_hid_connect_tolerates_open_oserror(monkeypatch, event_loop_for_setters):
+    """If ``open()`` raises OSError, connect() swallows it, leaves the connection
+    None, and does not propagate the error."""
+    conn = jablotron.JablotronConnectionHID("/dev/whatever")
+
+    def _boom(*_args, **_kwargs):
+        raise OSError("device gone")
+
+    monkeypatch.setattr(builtins, "open", _boom)
+
+    # Must not raise even though open() blows up.
+    event_loop_for_setters.run_until_complete(conn.connect())
+
+    assert conn.is_connected() is False
+    assert conn._connection is None
+
+
+# ---------------------------------------------------------------------------
+# reconnect() reports failure as a bool and leaves consistent state
+# ---------------------------------------------------------------------------
+def test_reconnect_returns_false_when_device_unopenable(
+    monkeypatch, event_loop_for_setters
+):
+    """reconnect() returns False when the device cannot be opened, and the
+    connection object's state stays consistent (disconnected, no exception)."""
+    conn = jablotron.JablotronConnectionHID("/dev/whatever")
+
+    def _boom(*_args, **_kwargs):
+        raise OSError("device gone")
+
+    monkeypatch.setattr(builtins, "open", _boom)
+
+    result = event_loop_for_setters.run_until_complete(conn.reconnect())
+
+    assert result is False
+    assert conn.is_connected() is False
+    assert conn._connection is None
+
+
+def test_reconnect_returns_true_when_open_succeeds(
+    monkeypatch, event_loop_for_setters
+):
+    """reconnect() returns True once the device opens again. A fake file-like
+    object stands in for the opened HID device so no real hardware is touched."""
+    conn = jablotron.JablotronConnectionHID("/dev/whatever")
+
+    class _FakeDevice:
+        def write(self, _data):
+            return None
+
+        def read(self, _n):
+            return b""
+
+        def flush(self):
+            return None
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(builtins, "open", lambda *a, **k: _FakeDevice())
+
+    result = event_loop_for_setters.run_until_complete(conn.reconnect())
+
+    assert result is True
+    assert conn.is_connected() is True
+
+
+# ---------------------------------------------------------------------------
+# RECONNECT_BACKOFF_SECONDS constant exists and is sane
+# ---------------------------------------------------------------------------
+def test_reconnect_backoff_constant_present():
+    """The packet loop relies on a module-level backoff constant."""
+    assert hasattr(jablotron, "RECONNECT_BACKOFF_SECONDS")
+    assert jablotron.RECONNECT_BACKOFF_SECONDS > 0
+
+
+# ---------------------------------------------------------------------------
+# #97 Part A: rf_level is a refresh candidate
+# ---------------------------------------------------------------------------
+def test_rf_level_is_a_real_sensor_object(event_loop_for_setters):
+    """The rf_level getter returns a JablotronSensor object (the thing the
+    sensor platform builds its entity from)."""
+    unit = _build_unit()
+    assert unit.rf_level is not None
+    assert isinstance(unit.rf_level, jablotron.JablotronSensor)
+    # Same identity as the private object that _refresh_all_entities collects.
+    assert unit.rf_level is unit._rf_level
+
+
+def test_refresh_all_entities_includes_rf_level(event_loop_for_setters, monkeypatch):
+    """The rf_level object must be among the objects _refresh_all_entities
+    publishes, so its availability flips with the connection (#97 Part A).
+
+    We capture every object publish_updates() is called on and assert the
+    rf_level object's identity is present.
+    """
+    unit = _build_unit()
+
+    published_ids = set()
+
+    async def _capture(self):
+        published_ids.add(id(self))
+
+    # Patch publish_updates on the base common class so every entity-backed
+    # object records that it was refreshed.
+    monkeypatch.setattr(
+        jablotron.JablotronCommon, "publish_updates", _capture, raising=True
+    )
+
+    event_loop_for_setters.run_until_complete(unit._refresh_all_entities())
+
+    assert id(unit._rf_level) in published_ids


### PR DESCRIPTION
Closes #97.

## Problem
The HID/serial read blocks waiting for data with no timeout, so a silently dead link (USB unplugged, panel powered off, passthrough wedged) raises no exception and entities keep showing their last state indefinitely.

## Change
- `JablotronConnection` records `_last_data_time` (set on construct and whenever real records arrive in `_forward_records`), exposed as `seconds_since_last_data`.
- `JA80CentralUnit.connection_alive` = data seen within `CONNECTION_DATA_TIMEOUT_SECONDS` (30s; the panel normally sends status packets ~1/s).
- A lightweight watchdog task (`CONNECTION_WATCHDOG_INTERVAL_SECONDS`, 10s), started in `initialize()`, refreshes all entities on a transition so HA re-reads availability (the read loop can be blocked in a thread, so a separate task is needed).
- `JablotronEntity.available` now also requires `connection_alive`.

## Tests
Adds a `tests/` suite (the repo had none) with a lightweight Home Assistant stub harness - no `homeassistant` install needed, just `pytest + pyserial + crccheck`. `test_connection_availability.py` covers the threshold logic and the `_forward_records` timestamping.

## Status
Logic is unit-tested; the end-to-end "pull the cable -> entities unavailable -> plug back -> recover" check on real hardware is recommended before merge. Opened as a draft for that and for feedback on the 30s timeout.
