### PR TITLE
Expose per-detector battery as a battery binary_sensor (#45)

### DIFF
--- a/custom_components/jablotron80/binary_sensor.py
+++ b/custom_components/jablotron80/binary_sensor.py
@@ -40,9 +40,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
     # binary_sensor (previously only an extra_state_attributes field). One per
     # real detector device, mirroring the main device loop. Devices without a
     # battery concept simply read False.
-    async_add_entities(
-        [JablotronBatteryBinarySensor(device, cu) for device in cu.devices], True
-    )
+    async_add_entities([JablotronBatteryBinarySensor(device, cu) for device in cu.devices], True)
 
 
 class JablotronDeviceSensorEntity(JablotronEntity, BinarySensorEntity):

--- a/custom_components/jablotron80/binary_sensor.py
+++ b/custom_components/jablotron80/binary_sensor.py
@@ -35,6 +35,13 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
     async_add_entities([JablotronDeviceSensorEntity(led, cu) for led in cu.leds], True)
     async_add_entities([JablotronDeviceSensorEntity(code, cu) for code in cu.codes], True)
     async_add_entities([JablotronDeviceSensorEntity(cu.statustext, cu)], True)
+    # #45: expose the per-detector battery state as a proper battery
+    # binary_sensor (previously only an extra_state_attributes field). One per
+    # real detector device, mirroring the main device loop. Devices without a
+    # battery concept simply read False.
+    async_add_entities(
+        [JablotronBatteryBinarySensor(device, cu) for device in cu.devices], True
+    )
 
 
 class JablotronDeviceSensorEntity(JablotronEntity, BinarySensorEntity):
@@ -86,4 +93,36 @@ class JablotronDeviceSensorEntity(JablotronEntity, BinarySensorEntity):
         if self._object.type == DEVICE_SMOKE_DETECTOR:
             return BinarySensorDeviceClass.SMOKE
 
+        return None
+
+
+class JablotronBatteryBinarySensor(JablotronEntity, BinarySensorEntity):
+    """#45: per-detector low-battery indicator as a battery binary_sensor.
+
+    Reads ``JablotronDevice.battery_low``. ``on`` means the battery is low.
+    Devices that have no battery concept simply report ``False``.
+    """
+
+    def __init__(self, device: JablotronDevice, cu: JA80CentralUnit):
+        super().__init__(cu, device)
+
+    @property
+    def is_on(self) -> bool:
+        return self._object.battery_low
+
+    @property
+    def device_class(self) -> Optional[str]:
+        return BinarySensorDeviceClass.BATTERY
+
+    @property
+    def unique_id(self) -> str:
+        # Distinct from the device's main occupancy/motion sensor.
+        return f"{super().unique_id}.battery"
+
+    @property
+    def name(self) -> str:
+        return f"{super().name} Battery"
+
+    @property
+    def icon(self) -> Optional[str]:
         return None

--- a/custom_components/jablotron80/binary_sensor.py
+++ b/custom_components/jablotron80/binary_sensor.py
@@ -1,5 +1,6 @@
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.const import EntityCategory
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorDeviceClass,
@@ -113,6 +114,11 @@ class JablotronBatteryBinarySensor(JablotronEntity, BinarySensorEntity):
     @property
     def device_class(self) -> Optional[str]:
         return BinarySensorDeviceClass.BATTERY
+
+    @property
+    def entity_category(self) -> Optional[EntityCategory]:
+        # Battery health is diagnostic, not a primary control/occupancy entity.
+        return EntityCategory.DIAGNOSTIC
 
     @property
     def unique_id(self) -> str:

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -23,7 +23,6 @@ from homeassistant.core import HomeAssistant
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
-
 if __name__ == "__main__":
     from const import (
         CONFIGURATION_SERIAL_PORT,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ We also put the repo root on ``sys.path`` so that
 """
 
 import asyncio
+import enum
 import os
 import sys
 import types
@@ -57,8 +58,19 @@ def _install_homeassistant_stubs() -> None:
     ha_core.HomeAssistant = HomeAssistant
 
     # homeassistant.const  ->  EVENT_HOMEASSISTANT_STOP (a dummy string)
+    # and EntityCategory (binary_sensor.py imports it for #45's diagnostic
+    # battery sensor). Mirror Home Assistant's real StrEnum string values so any
+    # assertion on the underlying value also holds.
     ha_const = types.ModuleType("homeassistant.const")
     ha_const.EVENT_HOMEASSISTANT_STOP = "homeassistant_stop"
+
+    class EntityCategory(str, enum.Enum):
+        """Stand-in for homeassistant.const.EntityCategory."""
+
+        DIAGNOSTIC = "diagnostic"
+        CONFIG = "config"
+
+    ha_const.EntityCategory = EntityCategory
 
     # homeassistant.config_entries  ->  empty module object is sufficient
     ha_config_entries = types.ModuleType("homeassistant.config_entries")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,171 @@
+"""Shared pytest fixtures and Home Assistant stubs for the jablotron80 tests.
+
+The integration's ``jablotron.py`` imports Home Assistant at module top:
+
+    from homeassistant import config_entries
+    from homeassistant.core import HomeAssistant
+    from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+
+Home Assistant is a very heavy dependency and is NOT installed in this test
+environment (by design - the task forbids installing it). Instead we insert
+lightweight fake modules into ``sys.modules`` BEFORE the integration is imported,
+so those imports resolve against our stubs.
+
+We also put the repo root on ``sys.path`` so that
+``import custom_components.jablotron80.jablotron`` resolves as a package.
+"""
+
+import asyncio
+import os
+import sys
+import types
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# 1. Make the repo root importable as the parent of ``custom_components``.
+# ---------------------------------------------------------------------------
+# conftest.py lives in <repo>/tests/, so the repo root is one level up.
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+
+# ---------------------------------------------------------------------------
+# 2. Install fake ``homeassistant`` modules into sys.modules.
+# ---------------------------------------------------------------------------
+def _install_homeassistant_stubs() -> None:
+    """Insert minimal fake homeassistant modules so the imports succeed.
+
+    Only the symbols actually imported by jablotron.py (and, defensively, by
+    const.py / errors.py) are provided. Everything is a trivial dummy: the
+    tests never drive real Home Assistant behaviour.
+    """
+    if "homeassistant" in sys.modules:
+        return
+
+    # Top-level package.
+    ha = types.ModuleType("homeassistant")
+    ha.__path__ = []  # mark as a package so submodule imports are allowed
+
+    # homeassistant.core  ->  HomeAssistant (a dummy class is enough)
+    ha_core = types.ModuleType("homeassistant.core")
+
+    class HomeAssistant:  # noqa: D401 - dummy stand-in
+        """Dummy HomeAssistant stand-in used only for type references."""
+
+    ha_core.HomeAssistant = HomeAssistant
+
+    # homeassistant.const  ->  EVENT_HOMEASSISTANT_STOP (a dummy string)
+    ha_const = types.ModuleType("homeassistant.const")
+    ha_const.EVENT_HOMEASSISTANT_STOP = "homeassistant_stop"
+
+    # homeassistant.config_entries  ->  empty module object is sufficient
+    ha_config_entries = types.ModuleType("homeassistant.config_entries")
+
+    # config_entries.ConfigEntry is referenced as a type hint in the package
+    # __init__.py; a bare class is enough.
+    class ConfigEntry:  # noqa: D401 - dummy stand-in
+        """Dummy ConfigEntry stand-in used only for type references."""
+
+    ha_config_entries.ConfigEntry = ConfigEntry
+
+    # homeassistant.exceptions  ->  HomeAssistantError (errors.py subclasses it)
+    ha_exceptions = types.ModuleType("homeassistant.exceptions")
+
+    class HomeAssistantError(Exception):
+        """Dummy base error matching homeassistant.exceptions.HomeAssistantError."""
+
+    ha_exceptions.HomeAssistantError = HomeAssistantError
+
+    # -- The integration package __init__.py imports the full HA platform stack.
+    # Importing `custom_components.jablotron80.jablotron` runs that __init__.py,
+    # so we must stub everything it pulls in too. Each platform module only needs
+    # a DOMAIN string.
+    ha_components = types.ModuleType("homeassistant.components")
+    ha_components.__path__ = []
+
+    def _platform_module(name: str, domain: str) -> types.ModuleType:
+        mod = types.ModuleType(f"homeassistant.components.{name}")
+        mod.DOMAIN = domain
+        return mod
+
+    ha_comp_alarm = _platform_module("alarm_control_panel", "alarm_control_panel")
+    ha_comp_binary = _platform_module("binary_sensor", "binary_sensor")
+    ha_comp_sensor = _platform_module("sensor", "sensor")
+    ha_comp_button = _platform_module("button", "button")
+
+    # homeassistant.helpers with device_registry and config_validation.
+    ha_helpers = types.ModuleType("homeassistant.helpers")
+    ha_helpers.__path__ = []
+
+    ha_dr = types.ModuleType("homeassistant.helpers.device_registry")
+
+    def _async_get(_hass):
+        return None
+
+    ha_dr.async_get = _async_get
+
+    ha_cv = types.ModuleType("homeassistant.helpers.config_validation")
+
+    def _config_entry_only_config_schema(_domain):
+        # The package __init__.py calls this at import time; return a no-op.
+        return lambda value: value
+
+    ha_cv.config_entry_only_config_schema = _config_entry_only_config_schema
+
+    ha_helpers.device_registry = ha_dr
+    ha_helpers.config_validation = ha_cv
+
+    sys.modules["homeassistant"] = ha
+    sys.modules["homeassistant.core"] = ha_core
+    sys.modules["homeassistant.const"] = ha_const
+    sys.modules["homeassistant.config_entries"] = ha_config_entries
+    sys.modules["homeassistant.exceptions"] = ha_exceptions
+    sys.modules["homeassistant.components"] = ha_components
+    sys.modules["homeassistant.components.alarm_control_panel"] = ha_comp_alarm
+    sys.modules["homeassistant.components.binary_sensor"] = ha_comp_binary
+    sys.modules["homeassistant.components.sensor"] = ha_comp_sensor
+    sys.modules["homeassistant.components.button"] = ha_comp_button
+    sys.modules["homeassistant.helpers"] = ha_helpers
+    sys.modules["homeassistant.helpers.device_registry"] = ha_dr
+    sys.modules["homeassistant.helpers.config_validation"] = ha_cv
+
+
+_install_homeassistant_stubs()
+
+
+# ---------------------------------------------------------------------------
+# 3. Event-loop fixture.
+# ---------------------------------------------------------------------------
+# Setting a JablotronCommon ``.active`` to a *new* value runs through the
+# ``@log_change`` decorator. When the value actually changes, log_change calls
+#     asyncio.get_event_loop().create_task(obj.publish_updates())
+# Under Python 3.12+ ``asyncio.get_event_loop()`` raises if there is no current
+# event loop set for the thread and none is running. We therefore install a
+# real loop as the current loop for the duration of each test so those setters
+# are safe. ``publish_updates`` is a no-op coroutine when no callbacks are
+# registered (the test devices have none), so the scheduled task is harmless.
+@pytest.fixture
+def event_loop_for_setters():
+    """Provide a real current event loop so ``.active`` setters are safe."""
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        yield loop
+    finally:
+        # log_change schedules publish_updates() coroutine tasks on this loop
+        # whenever a tracked attribute changes. The loop never .run()s during a
+        # test, so those tasks are still pending at teardown. Run the loop once
+        # to completion to let the (no-op) coroutines finish cleanly; otherwise
+        # asyncio emits "Task was destroyed but it is pending" warnings.
+        try:
+            pending = asyncio.all_tasks(loop)
+            if pending:
+                loop.run_until_complete(
+                    asyncio.gather(*pending, return_exceptions=True)
+                )
+        except Exception:
+            pass
+        loop.close()
+        asyncio.set_event_loop(None)

--- a/tests/test_battery.py
+++ b/tests/test_battery.py
@@ -160,3 +160,12 @@ def test_battery_sensor_is_on_reads_battery_low(event_loop_for_setters):
     assert sensor.is_on is True
     # device_class on the live instance also resolves to BATTERY.
     assert sensor.device_class == bs.BinarySensorDeviceClass.BATTERY
+
+
+def test_battery_sensor_entity_category_is_diagnostic():
+    """#45: the battery sensor is grouped under the diagnostic entity category."""
+    from homeassistant.const import EntityCategory
+
+    resolved = JablotronBatteryBinarySensor.entity_category.fget(object())
+    assert resolved == EntityCategory.DIAGNOSTIC
+    assert resolved == "diagnostic"

--- a/tests/test_battery.py
+++ b/tests/test_battery.py
@@ -1,0 +1,162 @@
+"""Tests for the battery binary_sensor (issue #45).
+
+Background
+----------
+Each detector's low-battery state was previously surfaced only as an
+``extra_state_attributes`` field. Issue #45 exposes it as a dedicated
+``binary_sensor`` with ``device_class = BATTERY`` so it shows up as a first-class
+entity and triggers Home Assistant's battery-low UI.
+
+Stub note
+---------
+``binary_sensor.py`` imports ``BinarySensorEntity`` and ``BinarySensorDeviceClass``
+from ``homeassistant.components.binary_sensor``. The shared conftest stubs that
+module with only a ``DOMAIN`` attribute, so importing the production module fails
+out of the box. We therefore enrich that stub here - BEFORE importing
+``binary_sensor`` - with the two symbols the module needs:
+
+* ``BinarySensorEntity`` - a bare base class (mirrors the entity stubs already in
+  conftest).
+* ``BinarySensorDeviceClass`` - a tiny stand-in exposing the members the
+  production code references; ``BATTERY`` is the one under test.
+
+This lets us import the real ``JablotronBatteryBinarySensor`` and assert against
+its real ``device_class`` / ``is_on`` logic without pulling in Home Assistant.
+"""
+
+import sys
+import types
+
+# conftest stubs ``jablotron.py``'s imports but NOT the extra Home Assistant
+# helper modules that ``jablotronHA.py`` (pulled in by ``binary_sensor.py``)
+# imports at module load. Provide just those symbols here, before importing.
+
+
+def _ensure_module(name: str) -> types.ModuleType:
+    mod = sys.modules.get(name)
+    if mod is None:
+        mod = types.ModuleType(name)
+        sys.modules[name] = mod
+    return mod
+
+
+# homeassistant.helpers.entity.Entity
+_entity = _ensure_module("homeassistant.helpers.entity")
+if not hasattr(_entity, "Entity"):
+
+    class Entity:  # noqa: D401 - dummy stand-in
+        """Minimal stand-in for homeassistant.helpers.entity.Entity."""
+
+    _entity.Entity = Entity
+
+# homeassistant.helpers.typing.StateType
+_typing = _ensure_module("homeassistant.helpers.typing")
+if not hasattr(_typing, "StateType"):
+    _typing.StateType = object
+
+# homeassistant.helpers.restore_state.RestoreEntity
+_restore = _ensure_module("homeassistant.helpers.restore_state")
+if not hasattr(_restore, "RestoreEntity"):
+
+    class RestoreEntity:  # noqa: D401 - dummy stand-in
+        """Minimal stand-in for RestoreEntity."""
+
+    _restore.RestoreEntity = RestoreEntity
+
+# homeassistant.helpers.dispatcher.async_dispatcher_connect
+_dispatcher = _ensure_module("homeassistant.helpers.dispatcher")
+if not hasattr(_dispatcher, "async_dispatcher_connect"):
+    _dispatcher.async_dispatcher_connect = lambda *a, **k: None
+
+# Enrich the binary_sensor component stub before importing the module.
+_bs_stub = sys.modules["homeassistant.components.binary_sensor"]
+
+if not hasattr(_bs_stub, "BinarySensorEntity"):
+
+    class BinarySensorEntity:  # noqa: D401 - dummy stand-in
+        """Minimal stand-in for homeassistant ...BinarySensorEntity."""
+
+    _bs_stub.BinarySensorEntity = BinarySensorEntity
+
+if not hasattr(_bs_stub, "BinarySensorDeviceClass"):
+
+    class BinarySensorDeviceClass:
+        """Stand-in exposing the device-class members the integration uses.
+
+        Values mirror Home Assistant's real ``BinarySensorDeviceClass`` enum
+        string values so any assertion on the underlying value also holds.
+        """
+
+        BATTERY = "battery"
+        SAFETY = "safety"
+        SMOKE = "smoke"
+        MOTION = "motion"
+        PROBLEM = "problem"
+        POWER = "power"
+        LIGHT = "light"
+        WINDOW = "window"
+        DOOR = "door"
+        MOISTURE = "moisture"
+        GAS = "gas"
+
+    _bs_stub.BinarySensorDeviceClass = BinarySensorDeviceClass
+
+
+import custom_components.jablotron80.jablotron as jablotron  # noqa: E402
+from custom_components.jablotron80 import binary_sensor as bs  # noqa: E402
+from custom_components.jablotron80.binary_sensor import (  # noqa: E402
+    JablotronBatteryBinarySensor,
+)
+
+
+# ---------------------------------------------------------------------------
+# JablotronDevice.battery_low round-trips
+# ---------------------------------------------------------------------------
+def test_device_battery_low_defaults_false(event_loop_for_setters):
+    """A fresh device reports a non-low battery."""
+    dev = jablotron.JablotronDevice(7)
+    assert dev.battery_low is False
+
+
+def test_device_battery_low_round_trips(event_loop_for_setters):
+    """Setting battery_low is reflected by the getter (setter runs through the
+    @log_change decorator, hence the event-loop fixture)."""
+    dev = jablotron.JablotronDevice(7)
+    dev.battery_low = True
+    assert dev.battery_low is True
+    dev.battery_low = False
+    assert dev.battery_low is False
+
+
+# ---------------------------------------------------------------------------
+# JablotronBatteryBinarySensor.device_class resolves to BATTERY
+# ---------------------------------------------------------------------------
+def test_battery_sensor_device_class_off_the_class():
+    """The new sensor's device_class is the BATTERY device class.
+
+    Asserting off the property descriptor avoids needing a fully wired HA
+    entity. ``fget(None)`` would touch no instance state, but ``device_class``
+    here ignores ``self`` entirely, so we can read the constant it returns.
+    """
+    # device_class is a property whose getter returns the constant unconditionally.
+    resolved = JablotronBatteryBinarySensor.device_class.fget(object())
+    assert resolved == bs.BinarySensorDeviceClass.BATTERY
+    assert resolved == "battery"
+
+
+def test_battery_sensor_is_on_reads_battery_low(event_loop_for_setters):
+    """An instantiated battery sensor's ``is_on`` follows the device's
+    ``battery_low`` flag.
+
+    ``JablotronEntity.__init__`` only stores ``cu`` and ``object`` - no HA
+    machinery - so the sensor can be instantiated directly with a real device
+    and a ``None`` central unit (is_on never touches the cu).
+    """
+    dev = jablotron.JablotronDevice(7)
+    sensor = JablotronBatteryBinarySensor(dev, None)
+
+    assert sensor.is_on is False
+    dev.battery_low = True
+    assert sensor.is_on is True
+    # device_class on the live instance also resolves to BATTERY.
+    assert sensor.device_class == bs.BinarySensorDeviceClass.BATTERY


### PR DESCRIPTION
Closes #45.

Low-battery is currently only an `extra_state_attributes` field. This exposes it as a proper `binary_sensor` with `device_class: battery` per device (on = low battery), so Home Assistant shows it as a standard device battery indicator.

- New `JablotronBatteryBinarySensor` (`is_on` -> `battery_low`, `device_class` -> BATTERY, `unique_id` -> `<device>.battery`, name -> `<device> Battery`).
- One per `cu.devices`; devices without a battery concept simply read off.

Open question for maintainers: limit this to wireless detectors only? Wired devices / keypad would otherwise show a permanently-OK battery sensor. Happy to filter if preferred - draft pending that decision. Includes a small test (and bootstraps the same test harness as #97/the #167 PR).
