### PR TITLE
Don't crash on unmapped beep code (#44)

### DIFF
--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -966,7 +966,10 @@ class JablotronKeyPress:
 
     @staticmethod
     def get_beep_option(code):
-        return JablotronKeyPress._BEEP_OPTIONS[code]
+        # #44: _BEEP_OPTIONS does not cover every code the panel can emit (e.g.
+        # 6). Look up defensively so an unmapped beep code degrades to "Unknown"
+        # instead of raising KeyError and breaking message parsing.
+        return JablotronKeyPress._BEEP_OPTIONS.get(code, "Unknown")
 
 
 class JablotronMessage:

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -20,7 +20,6 @@ _loop = None  # global variable to store event loop
 from typing import Any, Dict, Optional, Union, Callable
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
-
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
 

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -22,7 +22,6 @@ from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
-
 if __name__ == "__main__":
     from const import (
         CONFIGURATION_SERIAL_PORT,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,171 @@
+"""Shared pytest fixtures and Home Assistant stubs for the jablotron80 tests.
+
+The integration's ``jablotron.py`` imports Home Assistant at module top:
+
+    from homeassistant import config_entries
+    from homeassistant.core import HomeAssistant
+    from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+
+Home Assistant is a very heavy dependency and is NOT installed in this test
+environment (by design - the task forbids installing it). Instead we insert
+lightweight fake modules into ``sys.modules`` BEFORE the integration is imported,
+so those imports resolve against our stubs.
+
+We also put the repo root on ``sys.path`` so that
+``import custom_components.jablotron80.jablotron`` resolves as a package.
+"""
+
+import asyncio
+import os
+import sys
+import types
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# 1. Make the repo root importable as the parent of ``custom_components``.
+# ---------------------------------------------------------------------------
+# conftest.py lives in <repo>/tests/, so the repo root is one level up.
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+
+# ---------------------------------------------------------------------------
+# 2. Install fake ``homeassistant`` modules into sys.modules.
+# ---------------------------------------------------------------------------
+def _install_homeassistant_stubs() -> None:
+    """Insert minimal fake homeassistant modules so the imports succeed.
+
+    Only the symbols actually imported by jablotron.py (and, defensively, by
+    const.py / errors.py) are provided. Everything is a trivial dummy: the
+    tests never drive real Home Assistant behaviour.
+    """
+    if "homeassistant" in sys.modules:
+        return
+
+    # Top-level package.
+    ha = types.ModuleType("homeassistant")
+    ha.__path__ = []  # mark as a package so submodule imports are allowed
+
+    # homeassistant.core  ->  HomeAssistant (a dummy class is enough)
+    ha_core = types.ModuleType("homeassistant.core")
+
+    class HomeAssistant:  # noqa: D401 - dummy stand-in
+        """Dummy HomeAssistant stand-in used only for type references."""
+
+    ha_core.HomeAssistant = HomeAssistant
+
+    # homeassistant.const  ->  EVENT_HOMEASSISTANT_STOP (a dummy string)
+    ha_const = types.ModuleType("homeassistant.const")
+    ha_const.EVENT_HOMEASSISTANT_STOP = "homeassistant_stop"
+
+    # homeassistant.config_entries  ->  empty module object is sufficient
+    ha_config_entries = types.ModuleType("homeassistant.config_entries")
+
+    # config_entries.ConfigEntry is referenced as a type hint in the package
+    # __init__.py; a bare class is enough.
+    class ConfigEntry:  # noqa: D401 - dummy stand-in
+        """Dummy ConfigEntry stand-in used only for type references."""
+
+    ha_config_entries.ConfigEntry = ConfigEntry
+
+    # homeassistant.exceptions  ->  HomeAssistantError (errors.py subclasses it)
+    ha_exceptions = types.ModuleType("homeassistant.exceptions")
+
+    class HomeAssistantError(Exception):
+        """Dummy base error matching homeassistant.exceptions.HomeAssistantError."""
+
+    ha_exceptions.HomeAssistantError = HomeAssistantError
+
+    # -- The integration package __init__.py imports the full HA platform stack.
+    # Importing `custom_components.jablotron80.jablotron` runs that __init__.py,
+    # so we must stub everything it pulls in too. Each platform module only needs
+    # a DOMAIN string.
+    ha_components = types.ModuleType("homeassistant.components")
+    ha_components.__path__ = []
+
+    def _platform_module(name: str, domain: str) -> types.ModuleType:
+        mod = types.ModuleType(f"homeassistant.components.{name}")
+        mod.DOMAIN = domain
+        return mod
+
+    ha_comp_alarm = _platform_module("alarm_control_panel", "alarm_control_panel")
+    ha_comp_binary = _platform_module("binary_sensor", "binary_sensor")
+    ha_comp_sensor = _platform_module("sensor", "sensor")
+    ha_comp_button = _platform_module("button", "button")
+
+    # homeassistant.helpers with device_registry and config_validation.
+    ha_helpers = types.ModuleType("homeassistant.helpers")
+    ha_helpers.__path__ = []
+
+    ha_dr = types.ModuleType("homeassistant.helpers.device_registry")
+
+    def _async_get(_hass):
+        return None
+
+    ha_dr.async_get = _async_get
+
+    ha_cv = types.ModuleType("homeassistant.helpers.config_validation")
+
+    def _config_entry_only_config_schema(_domain):
+        # The package __init__.py calls this at import time; return a no-op.
+        return lambda value: value
+
+    ha_cv.config_entry_only_config_schema = _config_entry_only_config_schema
+
+    ha_helpers.device_registry = ha_dr
+    ha_helpers.config_validation = ha_cv
+
+    sys.modules["homeassistant"] = ha
+    sys.modules["homeassistant.core"] = ha_core
+    sys.modules["homeassistant.const"] = ha_const
+    sys.modules["homeassistant.config_entries"] = ha_config_entries
+    sys.modules["homeassistant.exceptions"] = ha_exceptions
+    sys.modules["homeassistant.components"] = ha_components
+    sys.modules["homeassistant.components.alarm_control_panel"] = ha_comp_alarm
+    sys.modules["homeassistant.components.binary_sensor"] = ha_comp_binary
+    sys.modules["homeassistant.components.sensor"] = ha_comp_sensor
+    sys.modules["homeassistant.components.button"] = ha_comp_button
+    sys.modules["homeassistant.helpers"] = ha_helpers
+    sys.modules["homeassistant.helpers.device_registry"] = ha_dr
+    sys.modules["homeassistant.helpers.config_validation"] = ha_cv
+
+
+_install_homeassistant_stubs()
+
+
+# ---------------------------------------------------------------------------
+# 3. Event-loop fixture.
+# ---------------------------------------------------------------------------
+# Setting a JablotronCommon ``.active`` to a *new* value runs through the
+# ``@log_change`` decorator. When the value actually changes, log_change calls
+#     asyncio.get_event_loop().create_task(obj.publish_updates())
+# Under Python 3.12+ ``asyncio.get_event_loop()`` raises if there is no current
+# event loop set for the thread and none is running. We therefore install a
+# real loop as the current loop for the duration of each test so those setters
+# are safe. ``publish_updates`` is a no-op coroutine when no callbacks are
+# registered (the test devices have none), so the scheduled task is harmless.
+@pytest.fixture
+def event_loop_for_setters():
+    """Provide a real current event loop so ``.active`` setters are safe."""
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        yield loop
+    finally:
+        # log_change schedules publish_updates() coroutine tasks on this loop
+        # whenever a tracked attribute changes. The loop never .run()s during a
+        # test, so those tasks are still pending at teardown. Run the loop once
+        # to completion to let the (no-op) coroutines finish cleanly; otherwise
+        # asyncio emits "Task was destroyed but it is pending" warnings.
+        try:
+            pending = asyncio.all_tasks(loop)
+            if pending:
+                loop.run_until_complete(
+                    asyncio.gather(*pending, return_exceptions=True)
+                )
+        except Exception:
+            pass
+        loop.close()
+        asyncio.set_event_loop(None)

--- a/tests/test_keypress.py
+++ b/tests/test_keypress.py
@@ -1,0 +1,64 @@
+"""Tests for the defensive ``get_beep_option`` lookup (issue #44).
+
+Background
+----------
+``JablotronKeyPress._BEEP_OPTIONS`` maps known beep codes to descriptions, but
+it is sparse - several codes the panel can emit (notably 6) have no entry.
+The old ``get_beep_option`` indexed the dict directly, so an unmapped code raised
+``KeyError`` and broke message parsing. The fix uses ``dict.get`` with an
+"Unknown" fallback.
+
+These tests only touch ``JablotronKeyPress``, a plain class with static methods,
+so no central unit or event loop is needed.
+"""
+
+import custom_components.jablotron80.jablotron as jablotron
+
+JablotronKeyPress = jablotron.JablotronKeyPress
+
+
+# ---------------------------------------------------------------------------
+# Defined codes still return their mapped values
+# ---------------------------------------------------------------------------
+def test_defined_beep_codes_return_mapped_values():
+    """Every key present in _BEEP_OPTIONS returns exactly its mapped entry."""
+    for code, expected in JablotronKeyPress._BEEP_OPTIONS.items():
+        assert JablotronKeyPress.get_beep_option(code) == expected
+
+
+def test_specific_known_codes():
+    """Spot-check a couple of known codes against their literal mappings."""
+    assert JablotronKeyPress.get_beep_option(0x0) == {
+        "val": "1s",
+        "desc": "1 subtle (short) beep triggered",
+    }
+    assert JablotronKeyPress.get_beep_option(0x1) == {
+        "val": "1l",
+        "desc": "1 loud (long) beep triggered",
+    }
+    assert JablotronKeyPress.get_beep_option(0xE) == {
+        "val": "?",
+        "desc": "unknown beep(s) triggered",
+    }
+
+
+# ---------------------------------------------------------------------------
+# The #44 regression: code 6 must NOT raise
+# ---------------------------------------------------------------------------
+def test_missing_code_6_returns_unknown_and_does_not_raise():
+    """The reported crash: code 6 is absent from _BEEP_OPTIONS.
+
+    Before the fix this raised KeyError; now it degrades to "Unknown".
+    """
+    # Guard the premise: 6 really is unmapped.
+    assert 6 not in JablotronKeyPress._BEEP_OPTIONS
+    # And the call is now safe.
+    assert JablotronKeyPress.get_beep_option(6) == "Unknown"
+
+
+def test_other_unmapped_codes_also_return_unknown():
+    """Any unmapped code falls back to "Unknown" rather than raising."""
+    for code in (0x6, 0x9, 0xA, 0xFF):
+        if code in JablotronKeyPress._BEEP_OPTIONS:
+            continue
+        assert JablotronKeyPress.get_beep_option(code) == "Unknown"


### PR DESCRIPTION
Closes #44.

`get_beep_option` indexes `_BEEP_OPTIONS[code]` and raises `KeyError` for codes not in the map (e.g. 6) - reported as 3285 occurrences in #44, breaking message parsing each time.

Defensive one-liner: `_BEEP_OPTIONS.get(code, "Unknown")`. It does not guess the protocol meaning of the unmapped code, it just stops the crash. Includes a test.
