### PR TITLE
Ack-independent staleness safety net + detector diagnostics (depends on #204)

### DIFF
--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -1984,6 +1984,13 @@ class JA80CentralUnit(object):
         # NEVER activates a device; it only turns off detectors the panel has
         # silently stopped reporting (e.g. a closed door whose "?" query
         # reconciliation never ran because the detail-query response overflowed).
+        #
+        # #208 follow-up fix: only sweep while DISARMED. When armed (or arming /
+        # entry-delay), the panel stops cycling the detail-query, so an open
+        # detector is no longer re-reported even though it is still physically
+        # open - sweeping then would falsely clear genuinely-open detectors.
+        if not JablotronState.is_disarmed_state(self._last_state):
+            return []
         now = time.monotonic()
         deactivated = []
         for device in self._active_devices.values():

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -21,6 +21,16 @@ _loop = None  # global variable to store event loop
 # integration recovers automatically once the device returns.
 RECONNECT_BACKOFF_SECONDS = 5
 
+# Time-based, ack-independent staleness sweep (issue #153 follow-up). With many
+# detectors open at once the "?" detail-query response can overflow and never get
+# acked, so the query-gated _update_device() never runs and a detector the panel
+# has stopped reporting (e.g. a closed door) stays stuck active=True. The panel's
+# status-text reports DO come through, so we record the last time each device was
+# reported active and deactivate any active device not re-reported within the
+# timeout. This ONLY deactivates, never activates. 120s is ~3 worst-case cycles.
+DEVICE_STALE_TIMEOUT_SECONDS = 120
+STALE_SWEEP_INTERVAL_SECONDS = 10
+
 
 from typing import Any, Dict, Optional, Union, Callable
 from homeassistant import config_entries
@@ -1523,6 +1533,13 @@ class JA80CentralUnit(object):
 
         self._active_devices = {}
         self._active_devices_tmp = {}
+        # #153 follow-up: device_id -> time.monotonic() of last active report,
+        # drives the ack-independent staleness sweep.
+        self._device_last_active = {}
+        # #153 follow-up: device_id -> wall-clock datetime of last active report,
+        # surfaced as a diagnostic entity attribute (the monotonic dict above is
+        # immune to clock changes and stays the source of truth for the sweep).
+        self._device_last_active_wall = {}
         self._active_codes = {}
         self._codes = {}
         self._device_query_pending = False
@@ -1641,6 +1658,8 @@ class JA80CentralUnit(object):
         _loop.create_task(self.processing_loop())
         asyncio.create_task(self._connection.read_send_packet_loop())
         asyncio.create_task(self._connection_watchdog())
+        # #153 follow-up: ack-independent safety-net sweep for stale detectors.
+        asyncio.create_task(self._stale_device_sweep_loop())
         await asyncio.wait_for(self._havestate.wait(), 20)
         LOGGER.info(f"initialization done.")
 
@@ -1944,6 +1963,10 @@ class JA80CentralUnit(object):
         if isinstance(source, JablotronDevice):
             source.active = True
             self._active_devices[source.device_id] = source
+            # #153 follow-up: record when this device was last reported active so
+            # the staleness sweep can deactivate it if the panel stops reporting it.
+            self._device_last_active[source.device_id] = time.monotonic()
+            self._device_last_active_wall[source.device_id] = datetime.datetime.now(datetime.timezone.utc)
             zone = self._get_zone_via_object(source)
             if not zone is None:
                 zone.device_activated(source)
@@ -1954,6 +1977,57 @@ class JA80CentralUnit(object):
         if isinstance(source, JablotronDevice):
             source.active = True
             self._active_devices_tmp[source.device_id] = source
+
+    def _sweep_stale_devices(self) -> list:
+        # #153 follow-up: ack-independent safety net. Deactivate any active device
+        # not re-reported active for longer than DEVICE_STALE_TIMEOUT_SECONDS. This
+        # NEVER activates a device; it only turns off detectors the panel has
+        # silently stopped reporting (e.g. a closed door whose "?" query
+        # reconciliation never ran because the detail-query response overflowed).
+        now = time.monotonic()
+        deactivated = []
+        for device in self._active_devices.values():
+            if device.active is not True:
+                continue
+            # Default to now so a device with no recorded timestamp is treated as
+            # just-seen and is NOT swept.
+            last = self._device_last_active.get(device.device_id, now)
+            if now - last > DEVICE_STALE_TIMEOUT_SECONDS:
+                LOGGER.info(
+                    f"Detector {device.device_id} not reported for "
+                    f">{DEVICE_STALE_TIMEOUT_SECONDS}s, marking inactive"
+                )
+                device.active = False
+                deactivated.append(device)
+        return deactivated
+
+    def _active_tracked_devices(self) -> list:
+        # #153 follow-up: active detectors that carry a last-active timestamp.
+        # The sweep loop republishes these every tick so their live attributes
+        # (seconds_since_reported / last_reported_active) refresh in the UI -
+        # which otherwise only happens when the device's own state changes.
+        return [
+            device
+            for device in self._active_devices.values()
+            if device.active is True and device.device_id in self._device_last_active
+        ]
+
+    async def _stale_device_sweep_loop(self) -> None:
+        # #153 follow-up: periodically run the ack-independent staleness sweep,
+        # then republish still-active detectors so their staleness attributes
+        # tick live (HA re-reads attributes only when an entity writes state).
+        while not self._stop.is_set():
+            await asyncio.sleep(STALE_SWEEP_INTERVAL_SECONDS)
+            for device in self._sweep_stale_devices():
+                try:
+                    await device.publish_updates()
+                except Exception:
+                    pass
+            for device in self._active_tracked_devices():
+                try:
+                    await device.publish_updates()
+                except Exception:
+                    pass
 
     def _fault_source(self, source_id: bytes) -> None:
         source = self._get_source(source_id)

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -672,6 +672,10 @@ class JablotronConnection:
         # #97: track when we last received data so a watchdog can detect a
         # silently dead connection (the HID read blocks without a timeout).
         self._last_data_time = time.monotonic()
+        # #153/#167 (heifisch): de-duplicate the repeated detail query so it
+        # doesn't pile up behind itself and block disarm.
+        self._cmd_list = []
+        self._send_cmd = None
 
     @property
     def seconds_since_last_data(self) -> float:
@@ -713,13 +717,25 @@ class JablotronConnection:
         return self._connection is not None
 
     async def add_command(self, command: JablotronCommand) -> None:
+        # #153/#167 (heifisch): de-duplicate ONLY the automatic "Details" detail
+        # query so repeated background queries don't pile up behind each other and
+        # block disarm. User/functional commands (arm, disarm, settings) are never
+        # de-duplicated, so a deliberately repeated arm/disarm sequence still goes
+        # through every time.
+        if command.name == "Details" and (command in self._cmd_list or command == self._send_cmd):
+            return
         LOGGER.debug(f"Adding command {command}")
+        self._cmd_list.append(command)
         await self._cmd_q.put(command)
 
     async def _get_command(self) -> Union[JablotronCommand, None]:
         if self._cmd_q.empty():
             return None
-        return await self._cmd_q.get()
+        cmd = await self._cmd_q.get()
+        if self._cmd_list:
+            self._cmd_list.pop(0)
+        self._send_cmd = cmd  # mark in flight for de-duplication
+        return cmd
 
     async def _forward_records(self, records: List[bytearray]) -> None:
         # #97: any data at all means the connection is alive; record the time so
@@ -775,7 +791,9 @@ class JablotronConnection:
                 if send_cmd is not None:
                     accepted = False
                     confirmed = False
-                    retries = 2
+                    # #153 (heifisch): more attempts so the detail query gets acked on flaky
+                    # comms; reconciliation only runs once a "Details" command is confirmed.
+                    retries = 10
 
                     while retries >= 0 and not (accepted and confirmed):
                         level = logging.INFO
@@ -821,6 +839,7 @@ class JablotronConnection:
                         retries -= 1
 
                     self._cmd_q.task_done()
+                    self._send_cmd = None
 
             except Exception:
                 LOGGER.exception("Unexpected error in packet loop")
@@ -1503,9 +1522,11 @@ class JA80CentralUnit(object):
         self._query.type = "button"
 
         self._active_devices = {}
+        self._active_devices_tmp = {}
         self._active_codes = {}
         self._codes = {}
         self._device_query_pending = False
+        self._force_query = False
         self._last_state = None
         self._mode = None
 
@@ -1859,18 +1880,12 @@ class JA80CentralUnit(object):
             return object.zone
 
     def _clear_triggers(self) -> None:
-        for device in self._devices.values():
-            # if self.system_mode == JA80CentralUnit.SYSTEM_MODE_UNSPLIT:
-            #    device.deactivate()
-            # else:
+        # #153 fix (heifisch): deactivate only currently-active sources; the persistent
+        # _active_devices/_active_codes registries stay populated for reconciliation.
+        for device in self._active_devices.values():
             device.active = False
-        self._active_devices.clear()
-        for code in self._codes.values():
-            # if self.system_mode == JA80CentralUnit.SYSTEM_MODE_UNSPLIT:
-            #    device.deactivate()
-            # else:
+        for code in self._active_codes.values():
             code.active = False
-        self._active_codes.clear()
 
     def _clear_source(self, source_id: bytes) -> None:
         source = self._get_source(source_id)
@@ -1890,6 +1905,7 @@ class JA80CentralUnit(object):
         source = self._get_source(source_id)
         if isinstance(source, JablotronDevice):
             self._activate_device(source)
+            self._activate_device_tmp(source)
         elif isinstance(source, JablotronCode):
             self._activate_code(source)
         else:
@@ -1914,12 +1930,15 @@ class JA80CentralUnit(object):
                 zone.code_activated(source)
 
     def _update_device(self):
-        for device in self._devices.values():
-            if device.device_id in self._active_devices:
+        # #153 fix (heifisch): reconcile against the set found in the current query round.
+        # A device in the persistent set but absent from this round (i.e. it closed) is
+        # turned off independently of other still-open detectors.
+        for device in self._active_devices.values():
+            if device.device_id in self._active_devices_tmp:
                 device.active = True
             else:
                 device.active = False
-        self._active_devices.clear()
+        self._active_devices_tmp.clear()
 
     def _activate_device(self, source):
         if isinstance(source, JablotronDevice):
@@ -1928,6 +1947,13 @@ class JA80CentralUnit(object):
             zone = self._get_zone_via_object(source)
             if not zone is None:
                 zone.device_activated(source)
+
+    def _activate_device_tmp(self, source):
+        # #153 fix (heifisch): record the device in the current query round so
+        # _update_device() can deactivate devices that are no longer reported.
+        if isinstance(source, JablotronDevice):
+            source.active = True
+            self._active_devices_tmp[source.device_id] = source
 
     def _fault_source(self, source_id: bytes) -> None:
         source = self._get_source(source_id)
@@ -2164,7 +2190,7 @@ class JA80CentralUnit(object):
             self.status = JA80CentralUnit.STATUS_NORMAL
             self._call_zones(function_name="disarm")
 
-            if activity == 0x00:  # and not self.led_alarm:
+            if activity == 0x00 and not self.led_alarm:
                 # clear active statuses
                 self._clear_triggers()
 
@@ -2291,8 +2317,13 @@ class JA80CentralUnit(object):
             # something is active
             if detail == 0x00:
                 # don't send query if we already have "triggered detector" displayed
-                if activity_name not in self.statustext.message or activity_name == self.statustext.message:
+                if (
+                    activity_name not in self.statustext.message
+                    or activity_name == self.statustext.message
+                    or self._force_query
+                ):
                     await self._send_device_query()
+                    self._force_query = False
                 else:
                     log = False
             else:
@@ -2322,6 +2353,9 @@ class JA80CentralUnit(object):
             else:
                 self._activate_source(detail)
                 self._confirm_device_query()
+            # #153 fix (heifisch): force a re-query on the next single-detector report so
+            # the active set is re-enumerated and closed detectors get reconciled off.
+            self._force_query = True
 
         else:
             warn = True

--- a/custom_components/jablotron80/jablotronHA.py
+++ b/custom_components/jablotron80/jablotronHA.py
@@ -1,3 +1,4 @@
+import time
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import StateType
 from typing import Any, Dict, List, Optional, Union
@@ -88,6 +89,22 @@ class JablotronEntity(Entity):
                 value = getattr(self._object, field)
                 if not value is None:
                     attr[field.replace("_", " ")] = getattr(self._object, field)
+        # #153 follow-up: surface when the panel last reported this detector as
+        # active, so the staleness behaviour is observable.
+        if isinstance(self._object, JablotronDevice):
+            device_id = self._object.device_id
+            # `last_reported_active` is a stable wall-clock timestamp ("last active
+            # at ..."); it stays visible even once the detector closes.
+            last_wall = self._cu._device_last_active_wall.get(device_id)
+            if last_wall is not None:
+                attr["last_reported_active"] = last_wall
+            # `seconds_since_reported` is a liveness metric: it only makes sense
+            # while the detector is active (it climbs until the sweep clears a
+            # stuck detector). On a closed detector it would freeze at a stale
+            # value, so we omit it entirely when inactive.
+            last_mono = self._cu._device_last_active.get(device_id)
+            if last_mono is not None and self._object.active:
+                attr["seconds_since_reported"] = round(time.monotonic() - last_mono)
         return attr
 
     @property

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,53 @@
+# jablotron80 starter test suite
+
+A small, runnable pytest suite for the `jablotron80` Home Assistant custom
+integration. It tests the integration's core logic **without installing Home
+Assistant** - `conftest.py` stubs the few `homeassistant.*` modules that
+`jablotron.py` (and the package `__init__.py`) import.
+
+## What is covered
+
+| File | What it protects |
+| --- | --- |
+| `test_reconciliation.py` | The **#153 per-sensor-close** logic: a closed detector turns off independently of another still-open one (`_activate_source` / `_update_device` on `JA80CentralUnit`). This is the most important test on the `fix/153-per-sensor-close` branch. |
+| `test_state.py` | `JablotronState` status-byte classification helpers (`is_armed_state`, `is_disarmed_state`, `is_alarm_state`, exit/entering delay, maintenance). |
+| `test_keypress.py` | `JablotronKeyPress.get_beep_option`, including upstream **issue #44** (`KeyError: 6` for the missing beep code), captured via `pytest.raises`. |
+
+## How the Home Assistant stub works
+
+`jablotron.py` imports `homeassistant.{core,const,config_entries}` at module top,
+and importing the `custom_components.jablotron80` package also runs its
+`__init__.py`, which pulls in the HA platform stack
+(`homeassistant.components.*`, `homeassistant.helpers.*`).
+
+`tests/conftest.py` inserts lightweight fake modules into `sys.modules` **before**
+the integration is imported, and adds the repo root to `sys.path` so that
+`import custom_components.jablotron80.jablotron` resolves as a package. No real
+Home Assistant install is required (or wanted).
+
+Setting a device's `.active` runs through a `@log_change` decorator that schedules
+`asyncio ... create_task(publish_updates())`. The `event_loop_for_setters` fixture
+installs a real current event loop so those setters are safe, and drains the
+no-op tasks at teardown.
+
+## Running
+
+From the repo root (`C:\dev\jablotron-upstream`):
+
+```powershell
+# one-time setup
+C:\Python314\python.exe -m venv .venv
+.\.venv\Scripts\python.exe -m pip install pytest pyserial crccheck
+
+# run the suite
+.\.venv\Scripts\python.exe -m pytest -v
+```
+
+Bash equivalent:
+
+```bash
+./.venv/Scripts/python.exe -m pytest -v
+```
+
+Home Assistant is deliberately **not** installed; the stubs in `conftest.py`
+provide everything the integration imports at module load time.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,6 +129,40 @@ def _install_homeassistant_stubs() -> None:
     ha_helpers.device_registry = ha_dr
     ha_helpers.config_validation = ha_cv
 
+    # homeassistant.helpers.entity / typing / restore_state / dispatcher are
+    # imported by jablotronHA.py. Only the names referenced there are needed:
+    # Entity and RestoreEntity as base classes (JablotronEntity never calls
+    # super().__init__, so plain classes suffice), StateType as an annotation
+    # alias, and async_dispatcher_connect as a callable.
+    ha_helpers_entity = types.ModuleType("homeassistant.helpers.entity")
+
+    class Entity:  # noqa: D401 - dummy stand-in
+        """Dummy Entity base used only so JablotronEntity can subclass it."""
+
+    ha_helpers_entity.Entity = Entity
+
+    ha_helpers_typing = types.ModuleType("homeassistant.helpers.typing")
+    ha_helpers_typing.StateType = object
+
+    ha_helpers_restore = types.ModuleType("homeassistant.helpers.restore_state")
+
+    class RestoreEntity:  # noqa: D401 - dummy stand-in
+        """Dummy RestoreEntity base."""
+
+    ha_helpers_restore.RestoreEntity = RestoreEntity
+
+    ha_helpers_dispatcher = types.ModuleType("homeassistant.helpers.dispatcher")
+
+    def _async_dispatcher_connect(*_args, **_kwargs):
+        return lambda: None
+
+    ha_helpers_dispatcher.async_dispatcher_connect = _async_dispatcher_connect
+
+    ha_helpers.entity = ha_helpers_entity
+    ha_helpers.typing = ha_helpers_typing
+    ha_helpers.restore_state = ha_helpers_restore
+    ha_helpers.dispatcher = ha_helpers_dispatcher
+
     sys.modules["homeassistant"] = ha
     sys.modules["homeassistant.core"] = ha_core
     sys.modules["homeassistant.const"] = ha_const
@@ -142,6 +176,10 @@ def _install_homeassistant_stubs() -> None:
     sys.modules["homeassistant.helpers"] = ha_helpers
     sys.modules["homeassistant.helpers.device_registry"] = ha_dr
     sys.modules["homeassistant.helpers.config_validation"] = ha_cv
+    sys.modules["homeassistant.helpers.entity"] = ha_helpers_entity
+    sys.modules["homeassistant.helpers.typing"] = ha_helpers_typing
+    sys.modules["homeassistant.helpers.restore_state"] = ha_helpers_restore
+    sys.modules["homeassistant.helpers.dispatcher"] = ha_helpers_dispatcher
 
 
 _install_homeassistant_stubs()

--- a/tests/test_command_dedup.py
+++ b/tests/test_command_dedup.py
@@ -1,0 +1,96 @@
+"""Tests for the narrowed command de-duplication (issue #153, maintainer feedback).
+
+Background
+----------
+The #153 port (heifisch) added de-duplication of queued commands in
+``JablotronConnection.add_command`` so that the automatic "Details" detail query
+does not pile up behind itself and block a disarm.
+
+The maintainer's concern: de-duplicating *every* command could silently drop a
+legitimate repeated command sequence (e.g. a user pressing disarm twice). The
+fix narrows the guard so that ONLY a "Details" command is de-duplicated;
+user/functional commands are always queued.
+
+These tests pin both halves of that contract:
+
+* two identical "Details" commands collapse to a single queued command, and
+* a non-"Details" command added twice is queued twice (never de-duplicated),
+
+while keeping the ``_cmd_q`` / ``_cmd_list`` bookkeeping balanced so that
+``_get_command``'s ``pop(0)`` stays consistent.
+"""
+
+import custom_components.jablotron80.jablotron as jablotron
+from custom_components.jablotron80.jablotron import (
+    JablotronCommand,
+    JablotronConnectionHID,
+)
+
+
+def _details_command() -> JablotronCommand:
+    """Build a fresh "Details" command equal to any other so-built one.
+
+    ``JablotronCommand`` is a dataclass, so two instances built with identical
+    fields compare equal - which is exactly what the de-dup guard relies on.
+    """
+    return JablotronCommand(name="Details", code=b"\x8e", accepted_prefix=b"\xa4\xff")
+
+
+def _user_command() -> JablotronCommand:
+    """Build a fresh non-"Details" (functional) command, e.g. a disarm keypress."""
+    return JablotronCommand(name="Disarm", code=b"\x8f", accepted_prefix=b"\xa0\xff")
+
+
+def test_repeated_details_command_is_deduplicated(event_loop_for_setters):
+    """Two identical "Details" queries collapse into a single queued command."""
+    loop = event_loop_for_setters
+    conn = JablotronConnectionHID("/dev/null")
+
+    loop.run_until_complete(conn.add_command(_details_command()))
+    loop.run_until_complete(conn.add_command(_details_command()))
+
+    # Only one survived: the second identical Details query was dropped.
+    assert conn._cmd_q.qsize() == 1
+    assert len(conn._cmd_list) == 1
+
+
+def test_repeated_user_command_is_not_deduplicated(event_loop_for_setters):
+    """A non-"Details" command added twice is queued twice (never de-duplicated).
+
+    This is the maintainer's requirement: a deliberately repeated functional
+    command (e.g. disarm pressed twice) must reach the panel both times.
+    """
+    loop = event_loop_for_setters
+    conn = JablotronConnectionHID("/dev/null")
+
+    loop.run_until_complete(conn.add_command(_user_command()))
+    loop.run_until_complete(conn.add_command(_user_command()))
+
+    # Both were queued - identical functional commands are NOT collapsed.
+    assert conn._cmd_q.qsize() == 2
+    assert len(conn._cmd_list) == 2
+
+
+def test_get_command_keeps_cmd_list_balanced_for_user_commands(event_loop_for_setters):
+    """Dequeuing pops exactly one ``_cmd_list`` entry per command, for any name.
+
+    The narrowed guard still appends every queued command to ``_cmd_list``, so
+    ``_get_command``'s ``pop(0)`` stays balanced even for non-"Details" commands.
+    """
+    loop = event_loop_for_setters
+    conn = JablotronConnectionHID("/dev/null")
+
+    loop.run_until_complete(conn.add_command(_user_command()))
+    loop.run_until_complete(conn.add_command(_user_command()))
+    assert len(conn._cmd_list) == 2
+
+    first = loop.run_until_complete(conn._get_command())
+    assert first is not None
+    # One dequeued -> exactly one popped from _cmd_list, and it is now in flight.
+    assert len(conn._cmd_list) == 1
+    assert conn._send_cmd is first
+
+    second = loop.run_until_complete(conn._get_command())
+    assert second is not None
+    assert len(conn._cmd_list) == 0
+    assert conn._cmd_q.empty()

--- a/tests/test_entity_attributes.py
+++ b/tests/test_entity_attributes.py
@@ -1,0 +1,100 @@
+"""Tests for the staleness diagnostic attributes on detector entities.
+
+The staleness sweep (issue #153 follow-up) records, per device, both a
+monotonic timestamp (drives the sweep) and a wall-clock timestamp. The entity
+layer surfaces these so the behaviour is observable in Home Assistant:
+
+* ``last_reported_active``   - wall-clock time the panel last reported the
+  detector as active.
+* ``seconds_since_reported`` - the age of that report in whole seconds; it
+  climbs until the panel re-reports the detector or the sweep clears it.
+
+These attributes only make sense for real detector devices, so they are added
+only when the backing object is a ``JablotronDevice`` and a record exists.
+"""
+
+import datetime
+
+import custom_components.jablotron80.jablotron as jablotron
+from custom_components.jablotron80.jablotronHA import JablotronEntity
+from custom_components.jablotron80.const import (
+    CABLE_MODEL,
+    CABLE_MODEL_JA82T,
+    CONFIGURATION_PASSWORD,
+    CONFIGURATION_SERIAL_PORT,
+)
+
+# A device id < 0x40 resolves to a JablotronDevice (>= 0x40 would be a code).
+DEVICE_ID = 6
+
+
+def _build_unit():
+    config = {
+        CABLE_MODEL: CABLE_MODEL_JA82T,
+        CONFIGURATION_SERIAL_PORT: "/dev/null",
+        CONFIGURATION_PASSWORD: "1234",
+    }
+    return jablotron.JA80CentralUnit(hass=None, config=config, options=None)
+
+
+def test_device_entity_exposes_timestamp_attributes(event_loop_for_setters):
+    """An active detector exposes both staleness attributes with sane values."""
+    unit = _build_unit()
+    unit._activate_source(DEVICE_ID)
+    device = unit.get_device(DEVICE_ID)
+
+    entity = JablotronEntity(unit, device)
+    attr = entity.extra_state_attributes
+
+    # Age attribute: present, a whole-second non-negative int.
+    assert "seconds_since_reported" in attr
+    assert isinstance(attr["seconds_since_reported"], int)
+    assert attr["seconds_since_reported"] >= 0
+
+    # Wall-clock attribute: present, tz-aware, and exactly the recorded value.
+    assert "last_reported_active" in attr
+    wall = attr["last_reported_active"]
+    assert isinstance(wall, datetime.datetime)
+    assert wall.tzinfo is not None
+    assert wall == unit._device_last_active_wall[DEVICE_ID]
+
+
+def test_device_without_record_omits_timestamp_attributes(event_loop_for_setters):
+    """With no recorded timestamp, neither staleness attribute is emitted.
+
+    The detector object still exists in the registry, but its entries in the
+    last-active dicts are gone (mirrors a device that has never been reported
+    active in this session). The ``.get()`` guards must then add nothing.
+    """
+    unit = _build_unit()
+    unit._activate_source(DEVICE_ID)
+    device = unit.get_device(DEVICE_ID)
+
+    # Drop both records so the .get() lookups return None.
+    unit._device_last_active.pop(DEVICE_ID, None)
+    unit._device_last_active_wall.pop(DEVICE_ID, None)
+
+    attr = JablotronEntity(unit, device).extra_state_attributes
+
+    assert "seconds_since_reported" not in attr
+    assert "last_reported_active" not in attr
+
+
+def test_closed_detector_keeps_timestamp_hides_age(event_loop_for_setters):
+    """A closed (inactive) detector keeps last_reported_active but drops the age.
+
+    `seconds_since_reported` is a liveness metric. Once the detector closes it
+    would otherwise freeze at a stale value, so it is omitted while inactive;
+    the stable `last_reported_active` timestamp remains visible.
+    """
+    unit = _build_unit()
+    unit._activate_source(DEVICE_ID)
+    device = unit.get_device(DEVICE_ID)
+
+    # Simulate the close: the detector goes inactive, timestamps are retained.
+    device.active = False
+
+    attr = JablotronEntity(unit, device).extra_state_attributes
+
+    assert "last_reported_active" in attr
+    assert "seconds_since_reported" not in attr

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -1,0 +1,157 @@
+"""Tests for the per-sensor-close reconciliation logic (issue #153).
+
+This is the core protection for the ``fix/153-per-sensor-close`` branch.
+
+Background
+----------
+The JA-80 central unit reports the set of currently-active (triggered) detectors
+in each query round. The integration keeps two structures:
+
+* ``_active_devices``      - a *persistent* registry of every device ever seen
+                             active. It is never cleared, so it can reconcile.
+* ``_active_devices_tmp``  - the set of devices seen active *in the current
+                             query round*. It is rebuilt every round.
+
+``_update_device()`` reconciles: any device in the persistent registry that is
+*absent* from the current round (i.e. its detector closed) is set inactive,
+independently of other detectors that are still open. That independence is the
+#153 fix - a single closed detector must turn off on its own.
+
+Each device id used here is ``< 0x40`` so that ``_get_source`` resolves it to a
+``JablotronDevice`` (ids >= 0x40 are codes, see ``JA80CentralUnit._get_source``).
+"""
+
+import custom_components.jablotron80.jablotron as jablotron
+from custom_components.jablotron80.const import (
+    CABLE_MODEL,
+    CABLE_MODEL_JA82T,
+    CONFIGURATION_PASSWORD,
+    CONFIGURATION_SERIAL_PORT,
+)
+
+# Two arbitrary device ids, both < 0x40 so they resolve to devices, not codes.
+DEVICE_OPEN_THEN_CLOSED = 6
+DEVICE_STAYS_OPEN = 22
+
+
+def _build_unit():
+    """Construct a JA80CentralUnit with a dummy hass and the smallest config.
+
+    ``JA80CentralUnit.__init__`` requires only the cable model, the serial port
+    and the master password; every other key is optional (the constructor
+    tolerates their absence). The JA-82T cable model routes to the HID
+    connection class, whose constructor does NOT open the serial port - only
+    ``connect()`` (called from ``initialize()``, which we never call) does.
+    """
+    config = {
+        CABLE_MODEL: CABLE_MODEL_JA82T,
+        CONFIGURATION_SERIAL_PORT: "/dev/null",
+        CONFIGURATION_PASSWORD: "1234",
+    }
+    return jablotron.JA80CentralUnit(hass=None, config=config, options=None)
+
+
+def test_unit_constructs_with_minimal_config(event_loop_for_setters):
+    """Sanity check: the smallest config constructs and starts empty."""
+    unit = _build_unit()
+    assert unit._active_devices == {}
+    assert unit._active_devices_tmp == {}
+
+
+def test_round1_two_devices_active(event_loop_for_setters):
+    """Round 1: activating two devices puts both in tmp + persistent, active."""
+    unit = _build_unit()
+
+    unit._activate_source(DEVICE_OPEN_THEN_CLOSED)
+    unit._activate_source(DEVICE_STAYS_OPEN)
+
+    dev6 = unit.get_device(DEVICE_OPEN_THEN_CLOSED)
+    dev22 = unit.get_device(DEVICE_STAYS_OPEN)
+
+    # Both devices report active immediately after activation.
+    assert dev6.active is True
+    assert dev22.active is True
+
+    # Both are tracked in the per-round (tmp) set and the persistent registry.
+    assert DEVICE_OPEN_THEN_CLOSED in unit._active_devices_tmp
+    assert DEVICE_STAYS_OPEN in unit._active_devices_tmp
+    assert DEVICE_OPEN_THEN_CLOSED in unit._active_devices
+    assert DEVICE_STAYS_OPEN in unit._active_devices
+
+
+def test_round1_update_keeps_both_active(event_loop_for_setters):
+    """Round 1 reconcile: tmp is cleared, both devices stay active.
+
+    Because both devices were reported in this round, ``_update_device`` must
+    keep both active and empty the per-round set.
+    """
+    unit = _build_unit()
+
+    unit._activate_source(DEVICE_OPEN_THEN_CLOSED)
+    unit._activate_source(DEVICE_STAYS_OPEN)
+    unit._update_device()
+
+    dev6 = unit.get_device(DEVICE_OPEN_THEN_CLOSED)
+    dev22 = unit.get_device(DEVICE_STAYS_OPEN)
+
+    assert unit._active_devices_tmp == {}
+    assert dev6.active is True
+    assert dev22.active is True
+
+
+def test_per_sensor_close_closes_only_the_absent_device(event_loop_for_setters):
+    """The #153 proof: a closed detector turns off independently.
+
+    Round 1: devices 6 and 22 are both open.
+    Round 2: only device 22 is reported (device 6 closed). After reconciliation,
+    device 6 must be inactive while device 22 stays active.
+
+    Contrast with the pre-fix behaviour: the old code cleared/kept triggers as a
+    group, so a single still-open detector (22) could keep a closed detector (6)
+    erroneously "active", or clearing one could wrongly clear the other. This
+    test fails on that regression and passes on the per-sensor-close fix.
+    """
+    unit = _build_unit()
+
+    # Round 1 - both detectors open.
+    unit._activate_source(DEVICE_OPEN_THEN_CLOSED)
+    unit._activate_source(DEVICE_STAYS_OPEN)
+    unit._update_device()
+
+    dev6 = unit.get_device(DEVICE_OPEN_THEN_CLOSED)
+    dev22 = unit.get_device(DEVICE_STAYS_OPEN)
+    assert dev6.active is True
+    assert dev22.active is True
+
+    # Round 2 - only device 22 is reported; device 6 has closed.
+    unit._activate_source(DEVICE_STAYS_OPEN)
+    unit._update_device()
+
+    # The closed detector turns off on its own ...
+    assert dev6.active is False
+    # ... while the still-open detector remains active.
+    assert dev22.active is True
+
+    # Device 6 stays in the persistent registry so it can reconcile again later.
+    assert DEVICE_OPEN_THEN_CLOSED in unit._active_devices
+    assert DEVICE_STAYS_OPEN in unit._active_devices
+
+
+def test_reopen_after_close_reactivates(event_loop_for_setters):
+    """A detail check: a device can close and then re-open across rounds."""
+    unit = _build_unit()
+    dev6 = unit.get_device(DEVICE_OPEN_THEN_CLOSED)
+
+    # Open, reconcile -> active.
+    unit._activate_source(DEVICE_OPEN_THEN_CLOSED)
+    unit._update_device()
+    assert dev6.active is True
+
+    # Absent next round -> closed.
+    unit._update_device()
+    assert dev6.active is False
+
+    # Reported again -> active once more.
+    unit._activate_source(DEVICE_OPEN_THEN_CLOSED)
+    unit._update_device()
+    assert dev6.active is True

--- a/tests/test_staleness_sweep.py
+++ b/tests/test_staleness_sweep.py
@@ -1,0 +1,187 @@
+"""Tests for the ack-independent staleness sweep (issue #153 follow-up).
+
+Background
+----------
+On a setup with many detectors open at once, the panel's "?" detail-query
+response can overflow and never get acked, so the query-ack-gated reconciliation
+in ``_update_device()`` never runs. A detector the panel has STOPPED reporting
+(e.g. a closed door) then stays stuck ``active=True`` in HA.
+
+The panel's status-text reports ("Triggered detector, X:name") DO come through
+reliably. ``_activate_device`` records ``time.monotonic()`` per device in
+``_device_last_active`` on every such report. ``_sweep_stale_devices`` is a
+time-based safety net: it deactivates any currently-active device not
+re-reported within ``DEVICE_STALE_TIMEOUT_SECONDS``. It ONLY deactivates; it
+never activates, and it leaves the device in ``_active_devices`` so it can
+re-activate later.
+
+Each device id used here is ``< 0x40`` so that ``_get_source`` resolves it to a
+``JablotronDevice`` (ids >= 0x40 are codes, see ``JA80CentralUnit._get_source``).
+"""
+
+import datetime
+import time
+
+import custom_components.jablotron80.jablotron as jablotron
+from custom_components.jablotron80.jablotron import (
+    DEVICE_STALE_TIMEOUT_SECONDS,
+    STALE_SWEEP_INTERVAL_SECONDS,
+)
+from custom_components.jablotron80.const import (
+    CABLE_MODEL,
+    CABLE_MODEL_JA82T,
+    CONFIGURATION_PASSWORD,
+    CONFIGURATION_SERIAL_PORT,
+)
+
+# Two arbitrary device ids, both < 0x40 so they resolve to devices, not codes.
+DEVICE_GOES_STALE = 6
+DEVICE_STAYS_FRESH = 22
+
+
+def _build_unit():
+    """Construct a JA80CentralUnit with a dummy hass and the smallest config.
+
+    Mirrors ``tests/test_reconciliation.py``: the JA-82T cable model routes to
+    the HID connection class, whose constructor does NOT open the serial port -
+    only ``connect()`` (called from ``initialize()``, never called here) does.
+    """
+    config = {
+        CABLE_MODEL: CABLE_MODEL_JA82T,
+        CONFIGURATION_SERIAL_PORT: "/dev/null",
+        CONFIGURATION_PASSWORD: "1234",
+    }
+    return jablotron.JA80CentralUnit(hass=None, config=config, options=None)
+
+
+def test_constants_are_sane():
+    """The sweep constants exist, are positive, and timeout > interval."""
+    assert DEVICE_STALE_TIMEOUT_SECONDS > 0
+    assert STALE_SWEEP_INTERVAL_SECONDS > 0
+    assert DEVICE_STALE_TIMEOUT_SECONDS > STALE_SWEEP_INTERVAL_SECONDS
+
+
+def test_activate_records_last_active(event_loop_for_setters):
+    """After activating device 6, a recent timestamp is recorded and it is active."""
+    unit = _build_unit()
+
+    before = time.monotonic()
+    unit._activate_source(DEVICE_GOES_STALE)
+    after = time.monotonic()
+
+    dev6 = unit.get_device(DEVICE_GOES_STALE)
+    assert dev6.active is True
+
+    # A timestamp exists for device 6 and it sits within the activation window.
+    assert DEVICE_GOES_STALE in unit._device_last_active
+    ts = unit._device_last_active[DEVICE_GOES_STALE]
+    assert before <= ts <= after
+
+
+def test_activate_records_wall_clock_timestamp(event_loop_for_setters):
+    """Activation also records a tz-aware wall-clock datetime for the attribute.
+
+    The monotonic dict drives the sweep; this parallel dict is what the entity
+    surfaces as ``last_reported_active``. It must be a timezone-aware datetime
+    (Home Assistant requires aware datetimes in attributes) and sit within a few
+    seconds of "now".
+    """
+    unit = _build_unit()
+
+    before = datetime.datetime.now(datetime.timezone.utc)
+    unit._activate_source(DEVICE_GOES_STALE)
+    after = datetime.datetime.now(datetime.timezone.utc)
+
+    assert DEVICE_GOES_STALE in unit._device_last_active_wall
+    wall = unit._device_last_active_wall[DEVICE_GOES_STALE]
+    assert isinstance(wall, datetime.datetime)
+    # Timezone-aware (not naive) so HA serialises/localises it correctly.
+    assert wall.tzinfo is not None
+    assert before <= wall <= after
+
+
+def test_sweep_deactivates_only_the_stale_device(event_loop_for_setters):
+    """A stale device turns off; a fresh one stays on; the stale one is retained.
+
+    Devices 6 and 22 are both active. Device 6's last-active timestamp is
+    back-dated beyond the timeout (stale); device 22 stays fresh. The sweep
+    must return device 6, set ``dev6.active is False``, leave ``dev22.active
+    is True``, and keep device 6 in ``_active_devices`` so it can re-activate.
+    """
+    unit = _build_unit()
+
+    unit._activate_source(DEVICE_GOES_STALE)
+    unit._activate_source(DEVICE_STAYS_FRESH)
+
+    dev6 = unit.get_device(DEVICE_GOES_STALE)
+    dev22 = unit.get_device(DEVICE_STAYS_FRESH)
+    assert dev6.active is True
+    assert dev22.active is True
+
+    # Back-date device 6 past the timeout; device 22 keeps its fresh timestamp.
+    unit._device_last_active[DEVICE_GOES_STALE] = (
+        time.monotonic() - (DEVICE_STALE_TIMEOUT_SECONDS + 30)
+    )
+
+    deactivated = unit._sweep_stale_devices()
+
+    # Only the stale device is returned and deactivated.
+    assert deactivated == [dev6]
+    assert dev6.active is False
+    # The fresh device is untouched.
+    assert dev22.active is True
+    # The stale device stays in the persistent registry for re-activation.
+    assert DEVICE_GOES_STALE in unit._active_devices
+
+
+def test_sweep_does_not_deactivate_fresh_or_untracked(event_loop_for_setters):
+    """Fresh (or timestamp-absent) active devices are never swept.
+
+    Both devices are freshly active. Additionally, the ``.get(..., now)``
+    default protects a device that has no entry in ``_device_last_active`` at
+    all: deleting device 22's timestamp must still leave it active after a
+    sweep. The sweep returns an empty list and changes nothing.
+    """
+    unit = _build_unit()
+
+    unit._activate_source(DEVICE_GOES_STALE)
+    unit._activate_source(DEVICE_STAYS_FRESH)
+
+    dev6 = unit.get_device(DEVICE_GOES_STALE)
+    dev22 = unit.get_device(DEVICE_STAYS_FRESH)
+
+    # Remove device 22's timestamp entirely -> the default-to-now guard applies.
+    del unit._device_last_active[DEVICE_STAYS_FRESH]
+
+    deactivated = unit._sweep_stale_devices()
+
+    assert deactivated == []
+    assert dev6.active is True
+    assert dev22.active is True
+
+
+def test_active_tracked_devices_lists_active_with_timestamp(event_loop_for_setters):
+    """Variant B: only active detectors carrying a timestamp are republished.
+
+    The sweep loop republishes this set every tick so the live staleness
+    attributes refresh in the UI. A deactivated device, or one without a
+    recorded timestamp, must drop out of the set.
+    """
+    unit = _build_unit()
+
+    unit._activate_source(DEVICE_GOES_STALE)
+    unit._activate_source(DEVICE_STAYS_FRESH)
+
+    dev6 = unit.get_device(DEVICE_GOES_STALE)
+    dev22 = unit.get_device(DEVICE_STAYS_FRESH)
+
+    # Both active and timestamped -> both refreshed, in activation order.
+    assert unit._active_tracked_devices() == [dev6, dev22]
+
+    # A deactivated detector drops out (no point refreshing an off entity).
+    dev22.active = False
+    assert unit._active_tracked_devices() == [dev6]
+
+    # An active detector without a recorded timestamp also drops out.
+    del unit._device_last_active[DEVICE_GOES_STALE]
+    assert unit._active_tracked_devices() == []

--- a/tests/test_staleness_sweep.py
+++ b/tests/test_staleness_sweep.py
@@ -109,6 +109,7 @@ def test_sweep_deactivates_only_the_stale_device(event_loop_for_setters):
     is True``, and keep device 6 in ``_active_devices`` so it can re-activate.
     """
     unit = _build_unit()
+    unit._last_state = jablotron.JablotronState.DISARMED
 
     unit._activate_source(DEVICE_GOES_STALE)
     unit._activate_source(DEVICE_STAYS_FRESH)
@@ -143,6 +144,7 @@ def test_sweep_does_not_deactivate_fresh_or_untracked(event_loop_for_setters):
     sweep. The sweep returns an empty list and changes nothing.
     """
     unit = _build_unit()
+    unit._last_state = jablotron.JablotronState.DISARMED
 
     unit._activate_source(DEVICE_GOES_STALE)
     unit._activate_source(DEVICE_STAYS_FRESH)
@@ -158,6 +160,34 @@ def test_sweep_does_not_deactivate_fresh_or_untracked(event_loop_for_setters):
     assert deactivated == []
     assert dev6.active is True
     assert dev22.active is True
+
+
+def test_sweep_skips_when_armed(event_loop_for_setters):
+    """#208 follow-up: the sweep must never deactivate while the system is armed.
+
+    When armed (or arming / entry-delay) the panel stops cycling the
+    detail-query, so an open detector is no longer re-reported even though it is
+    still open. A stale timestamp then does NOT mean "closed", so the sweep must
+    do nothing; once disarmed, the same stale device is swept again.
+    """
+    unit = _build_unit()
+    unit._activate_source(DEVICE_GOES_STALE)
+    dev6 = unit.get_device(DEVICE_GOES_STALE)
+
+    # Back-date past the timeout: this device WOULD be swept while disarmed.
+    unit._device_last_active[DEVICE_GOES_STALE] = time.monotonic() - (
+        DEVICE_STALE_TIMEOUT_SECONDS + 30
+    )
+
+    # Armed -> sweep is a no-op, the (still-open) detector stays active.
+    unit._last_state = jablotron.JablotronState.ARMED_ABC
+    assert unit._sweep_stale_devices() == []
+    assert dev6.active is True
+
+    # Disarmed -> the same stale detector is now swept off.
+    unit._last_state = jablotron.JablotronState.DISARMED
+    assert unit._sweep_stale_devices() == [dev6]
+    assert dev6.active is False
 
 
 def test_active_tracked_devices_lists_active_with_timestamp(event_loop_for_setters):

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,87 @@
+"""Tests for the ``JablotronState`` status-byte classification helpers.
+
+``JablotronState`` (in jablotron.py) maps raw status bytes from the central unit
+to logical states. The helpers tested here are pure static methods over the
+constants defined in the same class, so they are easy to assert against without
+constructing the unit.
+
+All expected values below are taken directly from the constants in
+``JablotronState`` - they are not guessed.
+"""
+
+import custom_components.jablotron80.jablotron as jablotron
+
+JablotronState = jablotron.JablotronState
+
+
+# ---------------------------------------------------------------------------
+# is_armed_state  (membership in STATES_ARMED)
+# ---------------------------------------------------------------------------
+def test_is_armed_state_for_armed_bytes():
+    # 0x43 = ARMED_ABC (unsplit/partial), 0x61 = ARMED_SPLIT_A.
+    assert JablotronState.is_armed_state(JablotronState.ARMED_ABC) is True
+    assert JablotronState.is_armed_state(JablotronState.ARMED_A) is True
+    assert JablotronState.is_armed_state(JablotronState.ARMED_SPLIT_A) is True
+
+
+def test_is_armed_state_false_for_disarmed():
+    # A disarmed byte must not classify as armed.
+    assert JablotronState.is_armed_state(JablotronState.DISARMED) is False
+
+
+# ---------------------------------------------------------------------------
+# is_disarmed_state  (membership in STATES_DISARMED)
+# ---------------------------------------------------------------------------
+def test_is_disarmed_state_for_disarmed_bytes():
+    # 0x40 unsplit/partial disarmed, 0x60 split disarmed.
+    assert JablotronState.is_disarmed_state(JablotronState.DISARMED) is True
+    assert JablotronState.is_disarmed_state(JablotronState.DISARMED_SPLIT) is True
+
+
+def test_is_disarmed_state_false_for_armed():
+    assert JablotronState.is_disarmed_state(JablotronState.ARMED_ABC) is False
+
+
+# ---------------------------------------------------------------------------
+# is_alarm_state  (membership in STATES_ALARM)
+# ---------------------------------------------------------------------------
+def test_is_alarm_state_for_alarm_bytes():
+    # 0x45 ALARM_A, 0x44 ALARM_WITHOUT_ARMING, 0x67 ALARM_C_SPLIT.
+    assert JablotronState.is_alarm_state(JablotronState.ALARM_A) is True
+    assert JablotronState.is_alarm_state(JablotronState.ALARM_WITHOUT_ARMING) is True
+    assert JablotronState.is_alarm_state(JablotronState.ALARM_C_SPLIT) is True
+
+
+def test_is_alarm_state_false_for_non_alarm():
+    assert JablotronState.is_alarm_state(JablotronState.DISARMED) is False
+    assert JablotronState.is_alarm_state(JablotronState.ARMED_ABC) is False
+
+
+# ---------------------------------------------------------------------------
+# exit-delay and entering-delay classification (membership lists)
+# ---------------------------------------------------------------------------
+def test_is_exit_delay_state():
+    # 0x53 EXIT_DELAY_ABC, 0x71 EXIT_DELAY_SPLIT_A.
+    assert JablotronState.is_exit_delay_state(JablotronState.EXIT_DELAY_ABC) is True
+    assert JablotronState.is_exit_delay_state(JablotronState.EXIT_DELAY_SPLIT_A) is True
+    assert JablotronState.is_exit_delay_state(JablotronState.DISARMED) is False
+
+
+def test_is_entering_delay_state():
+    # 0x49 ARMED_ENTRY_DELAY_A, 0x4B ARMED_ENTRY_DELAY_ABC.
+    assert JablotronState.is_entering_delay_state(JablotronState.ARMED_ENTRY_DELAY_A) is True
+    assert JablotronState.is_entering_delay_state(JablotronState.ARMED_ENTRY_DELAY_ABC) is True
+    assert JablotronState.is_entering_delay_state(JablotronState.DISARMED) is False
+
+
+# ---------------------------------------------------------------------------
+# maintenance classification (bitwise: MAINTENANCE set AND DISARMED bit clear)
+# ---------------------------------------------------------------------------
+def test_is_maintenance_state_true_for_maintenance_byte():
+    # MAINTENANCE = 0x20: 0x20 & 0x20 -> truthy, 0x20 & 0x40 -> 0 (not disarmed).
+    assert bool(JablotronState.is_maintenance_state(JablotronState.MAINTENANCE)) is True
+
+
+def test_is_maintenance_state_false_for_disarmed_byte():
+    # DISARMED = 0x40: the DISARMED bit is set, so it is explicitly not maintenance.
+    assert bool(JablotronState.is_maintenance_state(JablotronState.DISARMED)) is False


### PR DESCRIPTION
**Depends on #204** - this branch is stacked on `fix/153-per-sensor-close`, so until #204 is merged the diff here shows both #204 and this change. Once #204 lands, the diff reduces to just the staleness layer. Draft for that reason.

### What this adds
An ack-independent **staleness safety net** plus optional per-detector **diagnostics**.

With many detectors open at once, the panel's `?` detail-query response can overflow and never get acked, so the ack-gated reconciliation never runs and a detector the panel has *stopped* reporting (e.g. a closed door) stays stuck `on`. The status-text reports come through reliably, so `_activate_device` records `time.monotonic()` per device, and `_sweep_stale_devices` (every `STALE_SWEEP_INTERVAL_SECONDS`) deactivates any active device not re-reported within `DEVICE_STALE_TIMEOUT_SECONDS` (default 120s, ~3 worst-case cycles). It **only ever deactivates** - never activates, never fights the normal reconciliation.

### Diagnostics
- `last_reported_active` - wall-clock time the panel last reported the detector active (stays after it closes).
- `seconds_since_reported` - live age, shown **only while active** (a liveness metric; omitted once closed so it can't freeze on a stale value). Refreshed each sweep tick so it ticks up live.

### Relationship to #204
Functionally independent - the sweep works regardless of how reconciliation behaves - but complementary: #204 makes the per-sensor close precise, this is the ack-independent fallback for when reconciliation can't run at all.

### Testing
Live-tested on the reporter's hardware (868 MHz wireless, JA-82T, HA Core 2026.5.3): opening a window shows both attributes and the age ticks up; closing clears that sensor independently of other open ones and leaves only `last_reported_active`. 51 HA-stubbed unit tests (no HA install needed) cover the sweep, the live-refresh set, and the attributes. `black --line-length 110` clean.
