### PR TITLE
fix(#208): keep a single open detector fresh while its 0x10 query is suppressed

### DIFF
--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -1978,6 +1978,20 @@ class JA80CentralUnit(object):
             source.active = True
             self._active_devices_tmp[source.device_id] = source
 
+    def _refresh_active_detectors_last_seen(self) -> None:
+        # #208 follow-up: the panel still reports "triggered detector", but we
+        # suppress the keypad query (the detector is already shown). Refresh the
+        # known-active detectors' last-seen time so the staleness sweep does not
+        # falsely clear a still-open single detector. On close the panel stops
+        # reporting "triggered", the timestamp goes stale, and the sweep clears
+        # it as intended.
+        refresh_mono = time.monotonic()
+        refresh_wall = datetime.datetime.now(datetime.timezone.utc)
+        for device in self._active_devices.values():
+            if device.active is True:
+                self._device_last_active[device.device_id] = refresh_mono
+                self._device_last_active_wall[device.device_id] = refresh_wall
+
     def _sweep_stale_devices(self) -> list:
         # #153 follow-up: ack-independent safety net. Deactivate any active device
         # not re-reported active for longer than DEVICE_STALE_TIMEOUT_SECONDS. This
@@ -2407,6 +2421,10 @@ class JA80CentralUnit(object):
                     self._force_query = False
                 else:
                     log = False
+                    # #208 follow-up: keep still-open detectors fresh while the
+                    # query is suppressed, so the staleness sweep does not
+                    # falsely clear a genuinely-open single detector.
+                    self._refresh_active_detectors_last_seen()
             else:
                 self._activate_source(detail)
                 self._confirm_device_query()

--- a/tests/test_staleness_sweep.py
+++ b/tests/test_staleness_sweep.py
@@ -215,3 +215,57 @@ def test_active_tracked_devices_lists_active_with_timestamp(event_loop_for_sette
     # An active detector without a recorded timestamp also drops out.
     del unit._device_last_active[DEVICE_GOES_STALE]
     assert unit._active_tracked_devices() == []
+
+
+def test_refresh_keeps_active_detector_fresh(event_loop_for_setters):
+    """#208 follow-up: refreshing active detectors prevents a false stale-clear.
+
+    While the panel keeps reporting "triggered detector" but the keypad query is
+    suppressed (the detector is already shown), a single still-open detector must
+    have its last-seen time refreshed - otherwise the sweep would falsely clear
+    it. ``_refresh_active_detectors_last_seen`` is what the suppressed-0x10 path
+    calls; here we exercise it directly.
+    """
+    unit = _build_unit()
+    unit._last_state = jablotron.JablotronState.DISARMED
+    unit._activate_source(DEVICE_GOES_STALE)
+    dev6 = unit.get_device(DEVICE_GOES_STALE)
+
+    # Back-date past the timeout: without a refresh the sweep WOULD clear it.
+    unit._device_last_active[DEVICE_GOES_STALE] = time.monotonic() - (
+        DEVICE_STALE_TIMEOUT_SECONDS + 30
+    )
+
+    before = time.monotonic()
+    unit._refresh_active_detectors_last_seen()
+    after = time.monotonic()
+
+    # Monotonic timestamp refreshed into the just-now window.
+    ts = unit._device_last_active[DEVICE_GOES_STALE]
+    assert before <= ts <= after
+    # Wall-clock parallel dict refreshed too (drives last_reported_active).
+    assert DEVICE_GOES_STALE in unit._device_last_active_wall
+    # The detector is fresh again -> the sweep must NOT clear it.
+    assert unit._sweep_stale_devices() == []
+    assert dev6.active is True
+
+
+def test_refresh_ignores_inactive_detectors(event_loop_for_setters):
+    """Only active detectors are refreshed; an inactive one is left untouched.
+
+    A detector still tracked in ``_active_devices`` but already turned off must
+    not have its timestamp refreshed (otherwise it could never go stale/clear).
+    """
+    unit = _build_unit()
+    unit._activate_source(DEVICE_GOES_STALE)
+    dev6 = unit.get_device(DEVICE_GOES_STALE)
+    dev6.active = False  # detector reported closed
+
+    # Old timestamp; the refresh must not touch an inactive (but still tracked)
+    # device.
+    stale_ts = time.monotonic() - (DEVICE_STALE_TIMEOUT_SECONDS + 30)
+    unit._device_last_active[DEVICE_GOES_STALE] = stale_ts
+
+    unit._refresh_active_detectors_last_seen()
+
+    assert unit._device_last_active[DEVICE_GOES_STALE] == stale_ts


### PR DESCRIPTION
Follow-up to the ack-independent staleness sweep (#208).

### Problem (#209)
The sweep deactivates any active detector not re-reported within `DEVICE_STALE_TIMEOUT_SECONDS`. With a **single** open detector the panel keeps sending "triggered detector", but once it is already shown on the keypad the integration suppresses the detail-query - and on that suppressed path `_device_last_active` was never refreshed. After the timeout the sweep then falsely cleared a detector that is still physically open (HA flipped the door/window to "closed").

### Fix
On the suppressed-0x10 path, refresh the known-active detectors' last-seen time via a new `_refresh_active_detectors_last_seen()` helper. When the detector actually closes, the panel stops reporting "triggered", the timestamp goes stale, and the sweep clears it as intended.

### Tests
Two regression tests in `tests/test_staleness_sweep.py`:
- a back-dated single detector stays active after a refresh + sweep,
- an inactive (but still tracked) detector is not refreshed.

Full suite green, `black --line-length 110` clean.

### Validation
Verified live on a real JA-80K (JA-82T / USB-HID): a single open door that previously flipped to "closed" after ~2 min now stays correctly open until it is physically closed.

Closes #209
