### PR TITLE
fix(#165): don't crash the packet loop when the connection is torn down mid-read

### DIFF
--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -892,12 +892,18 @@ class JablotronConnectionHID(JablotronConnection):
         read_buffer = []
         ret_val = []
 
+        # #165: a concurrent disconnect/shutdown can set self._connection to None
+        # while this read loop is in flight; bail out cleanly instead of crashing
+        # on None.read ("Unexpected error in packet loop").
+        if self._connection is None:
+            return []
+
         for _ in range(max_package_sections):
             data = b""
             while data == b"":
                 try:
                     data = await asyncio.to_thread(self._connection.read, 64)
-                except OSError:
+                except (OSError, AttributeError):
                     await self.reconnect()
                     return []
 
@@ -963,11 +969,22 @@ class JablotronConnectionSerial(JablotronConnection):
         ret_val = []
         data = b""
 
+        # #165: bail out cleanly if a concurrent disconnect/shutdown set the
+        # connection to None while this read loop is in flight.
+        if self._connection is None:
+            return []
+
         while data == b"":
-            data = await asyncio.to_thread(self._connection.read_until, b"\xff")
+            try:
+                data = await asyncio.to_thread(self._connection.read_until, b"\xff")
+            except (OSError, AttributeError):
+                await self.reconnect()
+                return []
 
             if data == b"":
                 await self.reconnect()
+                if self._connection is None:
+                    return []
                 await asyncio.to_thread(
                     self._connection.read_until, b"\xff"
                 )  # discard first potentially corrupt record

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -903,7 +903,10 @@ class JablotronConnectionHID(JablotronConnection):
             while data == b"":
                 try:
                     data = await asyncio.to_thread(self._connection.read, 64)
-                except (OSError, AttributeError):
+                except (OSError, AttributeError, ValueError):
+                    # #165: None.read -> AttributeError; a closed underlying file ->
+                    # ValueError "I/O operation on closed file". Both occur on a
+                    # concurrent disconnect/shutdown - bail cleanly and reconnect.
                     await self.reconnect()
                     return []
 
@@ -977,7 +980,8 @@ class JablotronConnectionSerial(JablotronConnection):
         while data == b"":
             try:
                 data = await asyncio.to_thread(self._connection.read_until, b"\xff")
-            except (OSError, AttributeError):
+            except (OSError, AttributeError, ValueError):
+                # #165: also catch a closed-file ValueError, not just None.read.
                 await self.reconnect()
                 return []
 

--- a/tests/test_connection_guard.py
+++ b/tests/test_connection_guard.py
@@ -39,3 +39,26 @@ def test_read_data_returns_empty_when_connection_is_none(event_loop_for_setters)
     result = event_loop_for_setters.run_until_complete(conn._read_data())
 
     assert result == []
+
+
+def test_read_data_returns_empty_on_closed_file_valueerror(event_loop_for_setters):
+    """#165: a closed underlying handle raises ValueError ("I/O operation on closed
+    file") on read. The guard must bail cleanly (return []) just like for the None
+    case, instead of letting it surface as "Unexpected error in packet loop"."""
+    unit = _build_unit()
+    conn = unit._connection
+
+    class _ClosedHandle:
+        def read(self, *args, **kwargs):
+            raise ValueError("I/O operation on closed file")
+
+    conn._connection = _ClosedHandle()  # not None, but closed -> ValueError on read
+
+    async def _noop_reconnect():
+        return False
+
+    conn.reconnect = _noop_reconnect  # don't actually try to reopen during the test
+
+    result = event_loop_for_setters.run_until_complete(conn._read_data())
+
+    assert result == []

--- a/tests/test_connection_guard.py
+++ b/tests/test_connection_guard.py
@@ -1,0 +1,41 @@
+"""Tests for the connection-teardown guard in _read_data (issue #165).
+
+A concurrent disconnect/shutdown can set the connection's underlying handle to
+None while the read loop is still in flight (``read_until_found`` loops
+``_read_data`` without re-checking ``is_connected``). Before the guard this
+raised ``AttributeError: 'NoneType' object has no attribute 'read'`` and surfaced
+as "Unexpected error in packet loop". ``_read_data`` must now return ``[]``
+cleanly instead.
+
+The JA-82T cable routes to the HID connection class (``self._connection.read``);
+its constructor does not open the port, so the underlying handle is already None
+on a freshly built unit.
+"""
+
+import custom_components.jablotron80.jablotron as jablotron
+from custom_components.jablotron80.const import (
+    CABLE_MODEL,
+    CABLE_MODEL_JA82T,
+    CONFIGURATION_PASSWORD,
+    CONFIGURATION_SERIAL_PORT,
+)
+
+
+def _build_unit():
+    config = {
+        CABLE_MODEL: CABLE_MODEL_JA82T,
+        CONFIGURATION_SERIAL_PORT: "/dev/null",
+        CONFIGURATION_PASSWORD: "1234",
+    }
+    return jablotron.JA80CentralUnit(hass=None, config=config, options=None)
+
+
+def test_read_data_returns_empty_when_connection_is_none(event_loop_for_setters):
+    """#165: _read_data returns [] (no crash) when the underlying handle is None."""
+    unit = _build_unit()
+    conn = unit._connection  # the JablotronConnection manager (HID for JA-82T)
+    conn._connection = None  # connection torn down concurrently (shutdown/disconnect)
+
+    result = event_loop_for_setters.run_until_complete(conn._read_data())
+
+    assert result == []


### PR DESCRIPTION
### Problem (#165)
"Unexpected error in packet loop" with a traceback ending in `AttributeError: 'NoneType' object has no attribute 'read'` (or `read_until`).

A concurrent disconnect/shutdown sets the connection handle to `None` while the read loop is still in flight - `read_until_found` loops `_read_data` up to 10x without re-checking `is_connected()`, so a teardown mid-loop calls `self._connection.read(...)` on `None`. The HID `_read_data` only caught `OSError`; the serial `_read_data` had no error handling around `read_until` at all.

### Fix
Both `_read_data` variants (HID + serial) now:
- bail out cleanly (`return []`) if `self._connection is None` on entry, and
- treat `AttributeError` like `OSError` at the read call → reconnect and return `[]`.

A teardown or transient disconnect during a read now recovers gracefully instead of raising. No behaviour change on the happy path.

### Test
`tests/test_connection_guard.py`: `_read_data` with a `None` connection returns `[]` instead of raising.

### Note
Diagnosed from a live JA-80K (JA-82T / USB-HID): the traceback appears on every integration shutdown/restart, and the same race would hit any transient disconnect mid-command.

Closes #165
