### PR TITLE
fix(#132): keep the expected detail-query non-ack out of WARNING

### DIFF
--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -806,7 +806,6 @@ class JablotronConnection:
                     retries = 10
 
                     while retries >= 0 and not (accepted and confirmed):
-                        level = logging.INFO
                         for i in range(len(send_cmd.code)):
                             accepted_prefix = (
                                 send_cmd.accepted_prefix if i == len(send_cmd.code) - 1 else b"\xa0\xff"
@@ -823,8 +822,7 @@ class JablotronConnection:
                                 LOGGER.debug(f"keypress accepted, sequence:{i}")
                                 accepted = True
                             else:
-                                if retries == 0:
-                                    level = logging.WARN
+                                level = self._no_ack_log_level(send_cmd.name, retries)
                                 LOGGER.log(level, f"no accepted message for sequence:{i} received")
                                 accepted = False
                                 break
@@ -864,6 +862,20 @@ class JablotronConnection:
                 if record[: len(prefix)] == prefix:
                     return True
         return False
+
+    @staticmethod
+    def _no_ack_log_level(command_name: str, retries: int) -> int:
+        # The repeating background "Details" detail-query is EXPECTED not to be
+        # acked on most rounds: the JA-80 panel acks roughly one keypress in six,
+        # instantly or not at all. Reconciliation runs off the rounds that DO ack
+        # and the staleness sweep covers the rest, so a failed "Details" round is
+        # normal operation, not a fault - it must never reach WARN (otherwise the
+        # log fills with ~2-3 false warnings per minute). For real commands
+        # (arm/disarm, settings, esc) a missing ack on the FINAL retry IS
+        # meaningful and still escalates to WARN.
+        if retries == 0 and command_name != "Details":
+            return logging.WARN
+        return logging.INFO
 
 
 class JablotronConnectionHID(JablotronConnection):

--- a/tests/test_no_ack_log_level.py
+++ b/tests/test_no_ack_log_level.py
@@ -1,0 +1,50 @@
+"""Tests for the command-aware "no accepted message" log level.
+
+The repeating background "Details" detail-query is expected NOT to be acked on
+most rounds - the JA-80 panel acks roughly one keypress in six, instantly or not
+at all. Reconciliation runs off the rounds that DO ack, and the staleness sweep
+covers the rest, so a failed "Details" round is normal operation. Logging it at
+WARN floods the Home Assistant log with ~2-3 false warnings per minute, so the
+"Details" command never escalates to WARN. A real command (arm / disarm /
+settings / esc) that fails to ack on its FINAL retry IS meaningful and still
+warns.
+
+The key code 0x8e is shared by both "Details" and "Esc / back", so the
+distinction is made on the command NAME (its intent), not the key code: "Esc /
+back" still warns. The decision is isolated in
+``JablotronConnection._no_ack_log_level`` so it can be verified without driving
+the full async read/send loop.
+"""
+
+import logging
+
+import custom_components.jablotron80.jablotron as jablotron
+
+_level = jablotron.JablotronConnection._no_ack_log_level
+
+
+def test_details_never_warns_even_on_final_retry():
+    # retries == 0 is the last attempt; "Details" stays out of WARN there, and of
+    # course on every earlier attempt too.
+    assert _level("Details", 0) == logging.INFO
+    assert _level("Details", 10) == logging.INFO
+
+
+def test_real_command_warns_on_final_retry_only():
+    # A keypress sequence (arm/disarm) warns on the final retry...
+    assert _level("key sequence *HIDDEN*", 0) == logging.WARN
+    # ...but earlier attempts are still routine, no warning.
+    assert _level("key sequence *HIDDEN*", 3) == logging.INFO
+
+
+def test_other_real_commands_still_warn_on_final_retry():
+    # "Get settings" and "Esc / back" are deliberate, non-background commands.
+    assert _level("Get settings", 0) == logging.WARN
+    assert _level("Esc / back", 0) == logging.WARN
+
+
+def test_esc_back_shares_keycode_with_details_but_still_warns():
+    # Both send b"\x8e"; the suppression keys off the command NAME, not the code,
+    # so "Esc / back" must keep its final-retry warning while "Details" does not.
+    assert _level("Esc / back", 0) == logging.WARN
+    assert _level("Details", 0) == logging.INFO


### PR DESCRIPTION
## Problem

The repeating background "Details" detail-query gets logged at WARNING on its final retry whenever the panel does not ack it. On my JA-82K that is roughly 2-3 warnings per minute even when nothing is wrong - the `no accepted message for sequence:0 received` spam reported in #132.

## Why it is expected, not a fault

I traced this on a JA-82K (JA-82T USB cable) with debug logging on. The panel acks that keypress only about one time in six, and when it does, it answers immediately: the ack lands in the very first read cycle in 99.7% of the rounds that ack, and never later than the third. A missed ack just means the panel did not answer that particular keypress; the next query attempt gets a fresh chance. Device reconciliation runs off the rounds that do get acked, and the staleness net from #208 covers the rest, so a failed Details round is normal operation here.

## Change

Route the "no accepted message" log level through a small command-aware helper. The `Details` query stays at INFO, while real commands (arm / disarm / settings / esc) keep their WARNING on the final retry, where a missing ack actually means something. Note that keycode `0x8e` is shared between "Details" and "Esc / back", so the distinction is made on the command name, not the key code. Pure logging change - the read loop, reconciliation and timing are untouched.

## Validation

Live on a JA-82K for ~9 hours: WARNING `no accepted message` dropped from ~150-230 per hour to 0 per hour. The only warnings left in that window are real arm/disarm key sequences (confirmed by sequence number and timing); the Details misses now log at INFO (~9800 over the window). No errors or regressions.

Added `tests/test_no_ack_log_level.py`: Details never escalates to WARNING (even on the final retry); real commands still warn on the final retry; "Esc / back" (which shares `0x8e`) still warns, proving the split is by command name rather than key code.

refs #132
