### PR TITLE
[experimental] fix(#168): throttle the detail query + stop re-sending accepted commands

### DIFF
--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -31,6 +31,14 @@ RECONNECT_BACKOFF_SECONDS = 5
 DEVICE_STALE_TIMEOUT_SECONDS = 120
 STALE_SWEEP_INTERVAL_SECONDS = 10
 
+# #168: minimum spacing between background detail ("?") queries. Each query is an
+# ESC keypress on the shared bus; firing it on every detector cycle (~1-2s) keeps
+# the bus busy and cancels a keypad arm/bypass before the user can finish. Once the
+# open set is enumerated, stay quiet this long so the bus is free to arm. Opening is
+# still pushed by the panel instantly; only close-reconciliation lags (the staleness
+# sweep backs it up).
+DETAIL_QUERY_MIN_INTERVAL_SECONDS = 20
+
 
 from typing import Any, Dict, Optional, Union, Callable
 from homeassistant import config_entries
@@ -841,6 +849,17 @@ class JablotronConnection:
                                         LOGGER.warning(f"no completion message found for command {send_cmd}")
                                     send_cmd.confirm(False)
                                     continue
+                            else:
+                                # #168: a command with no completion handshake (the
+                                # background "Details" query and the arm/disarm key
+                                # sequences) is done the moment it is accepted - there is
+                                # nothing further to wait for. Mark it confirmed so the
+                                # loop exits now instead of re-sending the same keypress(es)
+                                # for every remaining retry (which floods the bus and, for
+                                # arm/disarm, re-enters the PIN ~11x - the #168 contention).
+                                # The retry budget is untouched for the not-yet-accepted
+                                # case: there `accepted` is False, so the loop keeps trying.
+                                confirmed = True
 
                             send_cmd.confirm(True)
                             if send_cmd.name == "Details":
@@ -1544,6 +1563,8 @@ class JA80CentralUnit(object):
         self._codes = {}
         self._device_query_pending = False
         self._force_query = False
+        # #168: monotonic time of the last detail query, for the send throttle.
+        self._last_device_query = 0.0
         self._last_state = None
         self._mode = None
 
@@ -2233,8 +2254,16 @@ class JA80CentralUnit(object):
         self.central_device.last_event = log
 
     async def _send_device_query(self) -> None:
-        if not self._device_query_pending:
-            await self.send_detail_command()
+        if self._device_query_pending:
+            return
+        # #168: throttle - do not re-query within DETAIL_QUERY_MIN_INTERVAL_SECONDS so
+        # the shared bus stays free between queries and the user can arm/bypass at the
+        # keypad without the query's ESC keypress cancelling it.
+        now = time.monotonic()
+        if now - self._last_device_query < DETAIL_QUERY_MIN_INTERVAL_SECONDS:
+            return
+        self._last_device_query = now
+        await self.send_detail_command()
 
     def _confirm_device_query(self) -> None:
         self._device_query_pending = False

--- a/tests/test_query_throttle.py
+++ b/tests/test_query_throttle.py
@@ -1,0 +1,57 @@
+"""Tests for the detail-query send throttle (issue #168).
+
+Each background detail ("?") query is an ESC keypress on the shared bus. Firing it
+on every detector cycle (~1-2s) keeps the bus busy and cancels a keypad arm/bypass
+before the user can finish. ``_send_device_query`` now enforces a minimum spacing
+of ``DETAIL_QUERY_MIN_INTERVAL_SECONDS`` between queries, leaving the bus free in
+between. The integration cannot see keypad input directly (it only reads its own
+echoes), so a time throttle is the practical equivalent of "pause while the user
+is at the keypad".
+"""
+
+import custom_components.jablotron80.jablotron as jablotron
+from custom_components.jablotron80.jablotron import DETAIL_QUERY_MIN_INTERVAL_SECONDS
+from custom_components.jablotron80.const import (
+    CABLE_MODEL,
+    CABLE_MODEL_JA82T,
+    CONFIGURATION_PASSWORD,
+    CONFIGURATION_SERIAL_PORT,
+)
+
+
+def _build_unit():
+    config = {
+        CABLE_MODEL: CABLE_MODEL_JA82T,
+        CONFIGURATION_SERIAL_PORT: "/dev/null",
+        CONFIGURATION_PASSWORD: "1234",
+    }
+    return jablotron.JA80CentralUnit(hass=None, config=config, options=None)
+
+
+def test_detail_query_is_throttled(event_loop_for_setters):
+    """A rapid second query is suppressed; once the interval elapses it goes out."""
+    unit = _build_unit()
+    sent = {"n": 0}
+
+    async def _fake_send():
+        sent["n"] += 1
+
+    unit.send_detail_command = _fake_send
+    loop = event_loop_for_setters
+
+    # First query goes out.
+    loop.run_until_complete(unit._send_device_query())
+    assert sent["n"] == 1
+
+    # An immediate second query is suppressed (still inside the min interval).
+    loop.run_until_complete(unit._send_device_query())
+    assert sent["n"] == 1
+
+    # Once the interval has elapsed, the next query goes out again.
+    unit._last_device_query -= DETAIL_QUERY_MIN_INTERVAL_SECONDS + 1
+    loop.run_until_complete(unit._send_device_query())
+    assert sent["n"] == 2
+
+
+def test_interval_constant_is_sane():
+    assert DETAIL_QUERY_MIN_INTERVAL_SECONDS >= 5

--- a/tests/test_send_loop_exit.py
+++ b/tests/test_send_loop_exit.py
@@ -1,0 +1,122 @@
+"""Tests for the send-loop early-exit on accept (issue #168).
+
+A command with no ``complete_prefix`` - the background "Details" query and the
+arm/disarm key sequences - used to keep re-sending its keypress(es) for every one
+of the 10 retries even after the panel had already accepted it, because the loop
+exit condition ``accepted and confirmed`` never became true (``confirmed`` is only
+set when a ``complete_prefix`` is found). That floods the bus and, for arm/disarm,
+re-enters the PIN ~11x - the root of #168 with several active sensors. The fix
+marks such a command confirmed on acceptance so the loop exits after one
+successful round, while leaving the full retry budget for the not-yet-accepted
+case.
+
+These tests drive ``read_send_packet_loop`` for exactly one queued command with a
+mocked connection and count how many keypresses actually go out on the wire.
+"""
+
+import custom_components.jablotron80.jablotron as jablotron
+from custom_components.jablotron80.jablotron import JablotronCommand
+from custom_components.jablotron80.const import (
+    CABLE_MODEL,
+    CABLE_MODEL_JA82T,
+    CONFIGURATION_PASSWORD,
+    CONFIGURATION_SERIAL_PORT,
+)
+
+
+def _build_conn():
+    config = {
+        CABLE_MODEL: CABLE_MODEL_JA82T,
+        CONFIGURATION_SERIAL_PORT: "/dev/null",
+        CONFIGURATION_PASSWORD: "1234",
+    }
+    unit = jablotron.JA80CentralUnit(hass=None, config=config, options=None)
+    return unit._connection  # the JablotronConnection manager (HID for JA-82T)
+
+
+class _CountingHandle:
+    """Stand-in for the underlying serial/HID handle: counts writes."""
+
+    def __init__(self):
+        self.writes = 0
+
+    def write(self, data):
+        self.writes += 1
+
+
+def _run_one_command(loop, conn, command, accept_results):
+    """Drive read_send_packet_loop for exactly one queued command.
+
+    ``accept_results`` is consumed one entry per ``read_until_found`` call (the
+    accept phase, plus the completion phase for commands with a complete_prefix);
+    it falls back to the last entry once exhausted. Returns the number of keypress
+    writes performed.
+    """
+    handle = _CountingHandle()
+    conn._connection = handle  # is_connected() -> True
+
+    calls = {"n": 0}
+
+    async def _fake_read_until_found(prefix, max_records=10):
+        i = calls["n"]
+        calls["n"] += 1
+        return accept_results[i] if i < len(accept_results) else accept_results[-1]
+
+    async def _fake_read_data(*args, **kwargs):
+        return []
+
+    async def _noop():
+        return None
+
+    conn.read_until_found = _fake_read_until_found
+    conn._read_data = _fake_read_data
+    conn.disconnect = _noop
+
+    async def _drive():
+        conn._stop.set()  # exit the loop once the queue drains
+        await conn._cmd_q.put(command)
+        await conn.read_send_packet_loop()
+
+    jablotron._loop = loop  # confirm() posts _event.set to the module-level loop
+    loop.run_until_complete(_drive())
+    return handle.writes
+
+
+def test_no_complete_prefix_sends_once_after_accept(event_loop_for_setters):
+    """#168: a Details-style command (no complete_prefix) writes its keypress ONCE
+    once accepted - no more re-sending for every remaining retry (was ~11)."""
+    conn = _build_conn()
+    cmd = JablotronCommand(name="Details", code=b"\x8e", accepted_prefix=b"\xa4\xff")
+
+    writes = _run_one_command(event_loop_for_setters, conn, cmd, [True])
+
+    assert writes == 1
+
+
+def test_no_complete_prefix_unaccepted_keeps_full_retry_budget(event_loop_for_setters):
+    """#168 guard: when the command is never accepted, the full retry budget is
+    still spent (11 attempts). The fix only short-circuits AFTER an accept."""
+    conn = _build_conn()
+    cmd = JablotronCommand(name="Details", code=b"\x8e", accepted_prefix=b"\xa4\xff")
+
+    writes = _run_one_command(event_loop_for_setters, conn, cmd, [False])
+
+    assert writes == 11  # retries 10..0 inclusive
+
+
+def test_complete_prefix_command_unchanged(event_loop_for_setters):
+    """A command WITH a complete_prefix still completes via its handshake and exits
+    after one round - the fix leaves that path untouched."""
+    conn = _build_conn()
+    cmd = JablotronCommand(
+        name="Get settings",
+        code=b"\x8a",
+        accepted_prefix=b"\xa1\xff",
+        complete_prefix=b"\xe6\x04",
+        max_records=300,
+    )
+
+    # call 0 = accept found, call 1 = completion found
+    writes = _run_one_command(event_loop_for_setters, conn, cmd, [True, True])
+
+    assert writes == 1


### PR DESCRIPTION
Experimental / opt-in. See #214. This trades detector-display latency for bus freedom and is not proposed as the default.

## Problem

The background detail ("?") query is an ESC keypress on the shared bus. With several sensors open the integration re-queries on every detector cycle (~45/min, about one ESC every 1.3s on my JA-82K), and that continuous ESC cancels a keypad arm/bypass before the user can confirm (#167/#168). The integration is blind to the wireless keypad (it only ever reads its own echoes), so it cannot detect user input to back off on its own.

## Changes

1. Throttle the detail query to at most one per `DETAIL_QUERY_MIN_INTERVAL_SECONDS` (20s), so the shared bus has quiet windows for a keypad arm/bypass. Trade-off: detector state is only seen on the next query, so open/close in HA lags up to the interval. Opening is not pushed separately by the panel, so this affects both directions.

2. A command with no completion handshake (the Details query and the arm/disarm key sequences) exits the send loop once accepted, instead of re-sending its keypress for every remaining retry. The retry budget is unchanged for the not-yet-accepted case.

## Validation

Live on a JA-82K: query rate dropped from ~45/min to ~6/min, leaving ~15s quiet windows on the bus; open/close detection lags 0-20s as expected. Unit tests drive the send loop and the throttle directly.

refs #168 #167
