### PR TITLE
fix(#181): guard the two arm-after-disarm race windows

### DIFF
--- a/custom_components/jablotron80/alarm_control_panel.py
+++ b/custom_components/jablotron80/alarm_control_panel.py
@@ -104,6 +104,15 @@ class Jablotron80AlarmControl(JablotronEntity, AlarmControlPanelEntity):
             return True
 
     async def async_alarm_disarm(self, code=None) -> None:
+        # #181: do not re-issue a disarm when the panel is already disarmed or
+        # mid-disarming. The master code toggles arm/disarm, so a redundant disarm
+        # keypress (e.g. an impatient second click) can flip it straight back into
+        # arming.
+        if self.alarm_state in (
+            AlarmControlPanelState.DISARMED,
+            AlarmControlPanelState.DISARMING,
+        ):
+            return
         if not self.code_disarm_required:
             code = self._cu._master_code
         if code == None:

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -615,6 +615,12 @@ class JablotronZone(JablotronCommon):
 
     @check_active
     def entering(self, by: Optional[JablotronDevice]) -> None:
+        # #181: if this zone is currently being disarmed, do not flip it into
+        # entry-delay. A disarm sets the zone to DISARMING; a stray entry-delay
+        # report arriving in that window would otherwise surface a spurious
+        # "alarm pending" right after the disarm.
+        if self.status == JablotronZone.STATUS_DISARMING:
+            return
         if not by is None:
             self.by = by
         self.status = JablotronZone.STATUS_ENTRY_DELAY

--- a/tests/test_arming_disarm_guards.py
+++ b/tests/test_arming_disarm_guards.py
@@ -1,0 +1,37 @@
+"""Tests for the #181 arming-after-disarm guards.
+
+Two small defensive guards prevent the "alarm re-arms / double alarm pending
+right after disarming" race:
+  1. a zone does not flip into entry-delay while it is being disarmed, and
+  2. the alarm entity does not re-issue a disarm when it is already disarmed or
+     mid-disarming (a redundant master-code keypress toggles the panel back into
+     arming, since the master code toggles arm/disarm).
+
+This covers the zone-level guard, which is plain state logic. The entity-level
+guard (`async_alarm_disarm`) depends on the full Home Assistant
+alarm_control_panel stack and is verified by review + live.
+"""
+
+from custom_components.jablotron80.jablotron import JablotronZone
+
+
+def test_entering_skipped_while_disarming(event_loop_for_setters):
+    """#181: entering() must NOT move a DISARMING zone into entry-delay."""
+    zone = JablotronZone(1)
+    zone.enabled = True
+    zone.status = JablotronZone.STATUS_DISARMING
+
+    zone.entering(None)
+
+    assert zone.status == JablotronZone.STATUS_DISARMING
+
+
+def test_entering_works_normally(event_loop_for_setters):
+    """A zone that is not disarming still enters entry-delay as before."""
+    zone = JablotronZone(2)
+    zone.enabled = True
+    zone.status = JablotronZone.STATUS_ARMED
+
+    zone.entering(None)
+
+    assert zone.status == JablotronZone.STATUS_ENTRY_DELAY


### PR DESCRIPTION
## What & why
Fixes the #181 "alarm re-arms / shows alarm-pending right after disarming" race.
The master code toggles arm/disarm, so a redundant disarm trigger - or a stray
entry-delay report arriving mid-disarm - can flip the panel straight back into
arming.

Two small, defensive guards:

1. JablotronZone.entering() ignores an entry-delay report while the zone is
   being disarmed (status DISARMING), so a stray report can't surface a spurious
   "alarm pending" right after a disarm.
2. async_alarm_disarm() does not re-issue a disarm when the panel is already
   disarmed or mid-disarming, so a redundant master-code keypress can't toggle
   it back into arming.

## Tests
New tests/test_arming_disarm_guards.py covers the zone-level guard. Full suite
green, black clean.

## Validation
Live-tested on a JA-82K: clean arm -> ~19 s exit delay -> armed -> disarm by
code. Disarm goes straight through, no re-arm, no entry-delay/pending afterwards,
ends disarmed; no errors in the log.

Credit: @ondrejmirtes for the original arming-guard idea (ddb29d33 / 4cb60386);
re-implemented against the async main.