### PR TITLE
feat: surface the panel clock and its drift vs HA time as read-only diagnostics

### DIFF
--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -1564,6 +1564,21 @@ class JA80CentralUnit(object):
         self._query.name = f"{CENTRAL_UNIT_MODEL} Query Button"
         self._query.type = "button"
 
+        # #151 read-only: the panel's own clock (day/month/hour/minute) as reported
+        # in event records, plus its drift vs HA time at that event. Both update ONLY
+        # when an event arrives (arm/disarm/alarm/...), not continuously. None until
+        # the first event so the sensors read "unknown" rather than a bogus value.
+        self._panel_time = JablotronSensor(5)
+        self._panel_time.name = f"{CENTRAL_UNIT_MODEL} Panel time"
+        self._panel_time.manufacturer = MANUFACTURER
+        self._panel_time.type = "panel_time"
+        self._panel_time._value = None
+        self._panel_time_drift = JablotronSensor(6)
+        self._panel_time_drift.name = f"{CENTRAL_UNIT_MODEL} Panel time drift"
+        self._panel_time_drift.manufacturer = MANUFACTURER
+        self._panel_time_drift.type = "panel_time_drift"
+        self._panel_time_drift._value = None
+
         self._active_devices = {}
         self._active_devices_tmp = {}
         # #153 follow-up: device_id -> time.monotonic() of last active report,
@@ -1809,6 +1824,14 @@ class JA80CentralUnit(object):
     @property
     def query(self) -> JablotronButton:
         return self._query
+
+    @property
+    def panel_time(self) -> JablotronSensor:
+        return self._panel_time
+
+    @property
+    def panel_time_drift(self) -> JablotronSensor:
+        return self._panel_time_drift
 
     @property
     def system_status(self) -> str:
@@ -2111,6 +2134,8 @@ class JA80CentralUnit(object):
 
     def _process_event(self, data: bytearray, packet_data: str) -> None:
         date_time_obj = self._get_timestamp(data[1:5])  # type: datetime.datetime
+        # #151 read-only: update the panel-clock + drift sensors from this event.
+        self._update_panel_clock(date_time_obj)
         event_type = data[5]
         event_name = "Unknown"  # default name to Unknown if we don't know what it is
         warn = False  # by defalt we will log an info message, but for important items we will install warn
@@ -2545,6 +2570,21 @@ class JA80CentralUnit(object):
         minutes = f"{data[3]:02x}"
         date_time_str = f"{self._year}-{month}-{day} {hours}:{minutes}"
         return datetime.datetime.strptime(date_time_str, "%Y-%m-%d %H:%M")
+
+    def _update_panel_clock(self, panel_dt) -> None:
+        # #151 read-only: surface the panel's own clock and its drift vs HA time.
+        # panel_dt is naive local time (minute resolution; year assumed). Make it
+        # tz-aware in the local zone and record the signed drift (panel - now) in
+        # whole seconds. Guarded so it never breaks event processing.
+        if panel_dt is None:
+            return
+        try:
+            local_tz = datetime.datetime.now().astimezone().tzinfo
+            aware = panel_dt.replace(tzinfo=local_tz)
+            self._panel_time.value = aware
+            self._panel_time_drift.value = round((aware - datetime.datetime.now(local_tz)).total_seconds())
+        except Exception:
+            pass
 
     def _process_settings(self, data: bytearray, packet_data: str) -> None:
         setting_type_1 = data[1]

--- a/custom_components/jablotron80/sensor.py
+++ b/custom_components/jablotron80/sensor.py
@@ -1,5 +1,6 @@
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.const import EntityCategory
 from homeassistant.helpers.entity import Entity
 from .jablotron import (
     JA80CentralUnit,
@@ -15,6 +16,7 @@ from .const import DATA_JABLOTRON, DOMAIN
 from homeassistant.components.sensor import SensorDeviceClass
 
 import logging
+import datetime
 
 LOGGER = logging.getLogger(__package__)
 
@@ -24,6 +26,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry, asyn
     async_add_entities([JablotronZoneSensorEntity(zone, cu) for zone in cu.zones], True)
     async_add_entities([JablotronSignalEntity(cu.rf_level, cu)], True)
     async_add_entities([JablotronSensorEntity(cu.alert, cu)], True)
+    # #151 read-only: the panel's own clock + its drift vs HA time (event-driven).
+    async_add_entities([JablotronPanelClockEntity(cu.panel_time, cu)], True)
+    async_add_entities([JablotronPanelDriftEntity(cu.panel_time_drift, cu)], True)
 
 
 class JablotronZoneSensorEntity(JablotronEntity):
@@ -73,3 +78,33 @@ class JablotronSignalEntity(JablotronSensorEntity):
     @property
     def device_class(self) -> str:
         return SensorDeviceClass.SIGNAL_STRENGTH
+
+
+class JablotronPanelClockEntity(JablotronSensorEntity):
+    # #151 read-only: the panel's own clock, shown as a literal HH:MM time. None until
+    # the first event provides a reading; minute resolution, year assumed by the
+    # integration. Deliberately NOT a TIMESTAMP device_class: HA renders timestamp
+    # sensors relative to now ("a minute ago"), which for a clock just ages
+    # confusingly. The companion drift sensor carries the numeric offset vs HA time.
+    @property
+    def state(self):
+        value = self._object.value
+        return value.strftime("%H:%M") if isinstance(value, datetime.datetime) else None
+
+    @property
+    def entity_category(self) -> Optional[EntityCategory]:
+        # The panel clock is diagnostic context for the drift, not a primary sensor.
+        return EntityCategory.DIAGNOSTIC
+
+
+class JablotronPanelDriftEntity(JablotronSensorEntity):
+    # #151 read-only: drift of the panel clock vs HA time at the last event, in
+    # whole seconds (signed: positive = panel ahead). Plain numeric, no device
+    # class - a drift can be negative, unlike a duration.
+    @property
+    def unit_of_measurement(self) -> str:
+        return "s"
+
+    @property
+    def entity_category(self) -> Optional[EntityCategory]:
+        return EntityCategory.DIAGNOSTIC

--- a/tests/test_panel_clock.py
+++ b/tests/test_panel_clock.py
@@ -1,0 +1,95 @@
+"""Tests for the read-only panel-clock + drift sensors (issue #151, read-only part).
+
+The panel reports its own clock (day/month/hour/minute; no year, no seconds) only
+in event records. ``_update_panel_clock`` exposes it as a tz-aware timestamp plus
+the signed drift (panel - HA now) in whole seconds. Both update only on events.
+"""
+
+import datetime
+
+import custom_components.jablotron80.jablotron as jablotron
+from custom_components.jablotron80.const import (
+    CABLE_MODEL,
+    CABLE_MODEL_JA82T,
+    CONFIGURATION_PASSWORD,
+    CONFIGURATION_SERIAL_PORT,
+)
+
+
+def _build_unit():
+    config = {
+        CABLE_MODEL: CABLE_MODEL_JA82T,
+        CONFIGURATION_SERIAL_PORT: "/dev/null",
+        CONFIGURATION_PASSWORD: "1234",
+    }
+    return jablotron.JA80CentralUnit(hass=None, config=config, options=None)
+
+
+def test_panel_clock_unset_until_first_event(event_loop_for_setters):
+    """Before any event the panel-clock and drift read None (sensor 'unknown')."""
+    unit = _build_unit()
+    assert unit.panel_time.value is None
+    assert unit.panel_time_drift.value is None
+
+
+def test_update_panel_clock_sets_aware_time_and_drift(event_loop_for_setters):
+    """An event timestamp becomes a tz-aware datetime; drift is signed seconds."""
+    unit = _build_unit()
+
+    # Panel reports a time ~90 s ahead of "now"; minute resolution loses the
+    # sub-minute part, but the drift stays clearly positive (panel ahead).
+    now = datetime.datetime.now()
+    panel_naive = (now + datetime.timedelta(seconds=90)).replace(second=0, microsecond=0)
+
+    unit._update_panel_clock(panel_naive)
+
+    pt = unit.panel_time.value
+    assert isinstance(pt, datetime.datetime)
+    assert pt.tzinfo is not None  # HA requires tz-aware timestamps
+    assert pt.hour == panel_naive.hour and pt.minute == panel_naive.minute
+
+    drift = unit.panel_time_drift.value
+    assert isinstance(drift, int)  # round() -> whole seconds
+    assert drift > 0  # panel is ahead
+
+
+def test_update_panel_clock_ignores_none(event_loop_for_setters):
+    """A None timestamp leaves the sensors untouched."""
+    unit = _build_unit()
+    unit._update_panel_clock(None)
+    assert unit.panel_time.value is None
+    assert unit.panel_time_drift.value is None
+
+
+# --- entity-render: the clock shows a literal HH:MM, not an aging relative time ---
+import homeassistant.components.sensor as _ha_sensor  # noqa: E402
+
+if not hasattr(_ha_sensor, "SensorDeviceClass"):
+
+    class SensorDeviceClass:  # noqa: D401 - minimal stand-in
+        TIMESTAMP = "timestamp"
+        SIGNAL_STRENGTH = "signal_strength"
+
+    _ha_sensor.SensorDeviceClass = SensorDeviceClass
+
+from custom_components.jablotron80.sensor import JablotronPanelClockEntity  # noqa: E402
+
+
+def test_panel_clock_entity_renders_hh_mm(event_loop_for_setters):
+    """The clock entity shows a literal HH:MM string (no relative 'x minutes ago')."""
+    unit = _build_unit()
+    now = datetime.datetime.now()
+    panel_naive = (now + datetime.timedelta(seconds=90)).replace(second=0, microsecond=0)
+    unit._update_panel_clock(panel_naive)
+
+    ent = JablotronPanelClockEntity(unit.panel_time, unit)
+    state = ent.state
+    assert state == unit.panel_time.value.strftime("%H:%M")
+    assert len(state) == 5 and state[2] == ":"
+
+
+def test_panel_clock_entity_none_before_event(event_loop_for_setters):
+    """Before any event the entity state is None (sensor shows 'unknown')."""
+    unit = _build_unit()
+    ent = JablotronPanelClockEntity(unit.panel_time, unit)
+    assert ent.state is None


### PR DESCRIPTION
## What & why
A small, read-only diagnostic slice inspired by #151 - it does NOT
resolve #151: there is no clock sync or correction here. It simply makes the
panel's own clock, and how far it has drifted from HA time, visible.

The panel keeps its own RTC, which slowly drifts from real time; until now that
was invisible. Two read-only diagnostic sensors, derived from the timestamp
already present in every panel event - no extra bus traffic, nothing written to
the panel:

- "Panel time" - the panel's clock as a literal HH:MM string. Intentionally NOT a
  timestamp device_class: HA renders those relative to now ("a minute ago"),
  which ages confusingly for a clock. None until the first event arrives.
- "Panel time drift" - signed offset of the panel clock vs HA time at the last
  event, in whole seconds (positive = panel ahead). Plain numeric, no device
  class (a drift can be negative, unlike a duration), unit "s".

Both are EntityCategory.DIAGNOSTIC and strictly read-only.

## Notes
- Event-driven: updates only when a panel event arrives, so they reflect the
  panel time as of the last event, not continuously.
- The drift is only meaningful when HA's own clock is correct (NTP).

## Tests / validation
Unit test (tests/test_panel_clock.py) covers the clock rendering and the drift
computation; full suite green, black clean. Live on a JA-82K: both sensors
populate on panel events, ~30 s drift observed.