### PR TITLE
feat: log which user code armed/disarmed, via a logbook event and last_used attribute

### DIFF
--- a/custom_components/jablotron80/const.py
+++ b/custom_components/jablotron80/const.py
@@ -6,6 +6,9 @@ import sys
 LOGGER = logging.getLogger(__package__)
 
 DOMAIN = "jablotron80"
+# #83/#98 follow-up: HA event fired when a code is used (arm/disarm), described
+# for the logbook in logbook.py.
+EVENT_CODE_USED = "jablotron_code_used"
 NAME = "Jablotron 80"
 MANUFACTURER = "Jablotron"
 CENTRAL_UNIT_MODEL = "JA-80K"

--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -70,6 +70,8 @@ else:
         CONFIGURATION_CENTRAL_SETTINGS,
         DEVICE_CONFIGURATION_REQUIRE_CODE_TO_ARM,
         DEVICE_CONFIGURATION_SYSTEM_MODE,
+        DOMAIN,
+        EVENT_CODE_USED,
     )
 
 
@@ -1575,6 +1577,10 @@ class JA80CentralUnit(object):
         self._device_last_active_wall = {}
         self._active_codes = {}
         self._codes = {}
+        # #83: code_id -> wall-clock datetime the code was last used (arm/disarm).
+        # Surfaced as a `last_used` attribute on the code entities; the existing
+        # active/inactive state is unchanged (non-breaking).
+        self._code_last_used_wall = {}
         self._device_query_pending = False
         self._force_query = False
         self._last_state = None
@@ -1963,23 +1969,75 @@ class JA80CentralUnit(object):
         else:
             LOGGER.warning(f"Unknown source type {source_id}")
 
-    def _activate_code(self, code_id):
+    def _activate_code(self, code_id, action=None):
         code = self._get_source(code_id)
-        self._activate_code_object(code)
+        self._activate_code_object(code, action)
 
     def _clear_code(self, code_id):
         code = self._get_source(code_id)
         if isinstance(code, JablotronCode):
             code.active = False
 
-    def _activate_code_object(self, source):
+    def _activate_code_object(self, source, action=None):
         # is there need to trigger state for code?
         if isinstance(source, JablotronCode):
+            was_active = source.active
             self._active_codes[source._id] = source
             source.active = True
+            # #83: record when this code was last used (arm/disarm).
+            self._code_last_used_wall[source._id] = datetime.datetime.now(datetime.timezone.utc)
+            # #83/#98 follow-up: fire a logbook event on each fresh code use so every
+            # code gets its own usage history (logbook.py describes it and links it to
+            # the code entity). Only on the off->on transition = one entry per use.
+            if not was_active and self._hass is not None:
+                self._fire_code_used_event(source, action)
             zone = self._get_zone_via_object(source)
             if not zone is None:
                 zone.code_activated(source)
+
+    def _fire_code_used_event(self, source, action=None) -> None:
+        # #83/#98: emit one logbook event per code use; logbook.py renders it.
+        # Callers guard that self._hass is not None. `action` ("arm"/"disarm") lets the
+        # describer say "was used to arm/disarm"; None (e.g. panic/tamper code use)
+        # renders as plain "was used".
+        unique_id = f"{DOMAIN}.{self.serial_port}.{source.id_part}.{source._id}"
+        # #83/#98 follow-up: include the resolved entity_id. HA associates a recorded
+        # event with an entity via event.data["entity_id"], and the entity-scoped
+        # logbook (the code's own "Activity") filters on that. Without it the entry
+        # shows only in the GLOBAL logbook, not on the code entity itself.
+        entity_id = None
+        try:
+            from homeassistant.helpers import entity_registry as er
+
+            entity_id = er.async_get(self._hass).async_get_entity_id("binary_sensor", DOMAIN, unique_id)
+        except Exception:
+            entity_id = None
+        self._hass.bus.async_fire(
+            EVENT_CODE_USED,
+            {
+                "code_id": source._id,
+                "name": source.name,
+                "unique_id": unique_id,
+                "entity_id": entity_id,
+                "action": action,
+            },
+        )
+
+    def _record_code_use(self, code_id, action="disarm") -> None:
+        # #83/#98 follow-up: arming routes through _activate_code -> _activate_code_object,
+        # which records the use and fires the logbook event. Disarming (Unsetting / alarm
+        # cancelled by user) only clears the code via _clear_code, so the use was never
+        # recorded and no entry ever appeared. Record it here, without marking the code
+        # active (the disarm clears it).
+        code = self._get_source(code_id)
+        if not isinstance(code, JablotronCode):
+            return
+        self._code_last_used_wall[code._id] = datetime.datetime.now(datetime.timezone.utc)
+        if self._hass is not None:
+            self._fire_code_used_event(code, action)
+            # disarm does not toggle code.active, so no @log_change render fires here;
+            # trigger one explicitly so the code entity's last_used attribute updates.
+            asyncio.get_event_loop().create_task(code.publish_updates())
 
     def _update_device(self):
         # #153 fix (heifisch): reconcile against the set found in the current query round.
@@ -2149,13 +2207,16 @@ class JA80CentralUnit(object):
             self._fault_source(source)
         elif event_type == 0x08:
             event_name = "Setting"
-            self._activate_code(source)
+            self._activate_code(source, action="arm")
             self._clear_triggers()
             self._call_zones(function_name="arming", source_id=source)
         elif event_type == 0x09:
             event_name = "Unsetting"
             # unsetting, source = by which code
             self._clear_code(source)
+            # #83/#98 follow-up: disarm attributes the code but never activates it, so
+            # record the code use here for the per-code usage logbook.
+            self._record_code_use(source)
             self._call_zones(function_name="disarm", source_id=source)
         elif event_type == 0x0C:
             event_name = "Completely set without code"
@@ -2163,7 +2224,7 @@ class JA80CentralUnit(object):
             self._call_zones(function_name="arming", source_id=source)
         elif event_type == 0x0D:
             event_name = "Partial Set A"
-            self._activate_code(source)
+            self._activate_code(source, action="arm")
             self._call_zone(1, by=source, function_name="arming")
         elif event_type == 0x0E:
             event_name = "Lost communication with device"
@@ -2192,15 +2253,15 @@ class JA80CentralUnit(object):
             self._activate_source(source)
         elif event_type == 0x1A:
             event_name = "Setting Zone A"
-            self._activate_code(source)
+            self._activate_code(source, action="arm")
             self._call_zone(1, by=source, function_name="arming")
         elif event_type == 0x1B:
             event_name = "Setting Zone B"
-            self._activate_code(source)
+            self._activate_code(source, action="arm")
             self._call_zone(2, by=source, function_name="arming")
         elif event_type == 0x21:
             event_name = "Partial Set A,B"
-            self._activate_code(source)
+            self._activate_code(source, action="arm")
             self._call_zone(1, by=source, function_name="arming")
             self._call_zone(2, by=source, function_name="arming")
         elif event_type == 0x40:
@@ -2216,6 +2277,8 @@ class JA80CentralUnit(object):
             # alarm cancelled / disarmed, source = by which code
             self._clear_triggers()
             # code is specific to zone or master TODO
+            # #83/#98 follow-up: record the cancelling code for the per-code logbook.
+            self._record_code_use(source)
             self._call_zones(function_name="disarm", source_id=source)
         elif event_type == 0x50:
             # received when all tamper alarms are removed (though alarm warnings may be present via status messages)

--- a/custom_components/jablotron80/jablotronHA.py
+++ b/custom_components/jablotron80/jablotronHA.py
@@ -10,7 +10,7 @@ from .const import (
     CENTRAL_UNIT_MODEL,
     DEVICES,
 )
-from .jablotron import JA80CentralUnit, JablotronDevice, JablotronZone, JablotronCommon
+from .jablotron import JA80CentralUnit, JablotronDevice, JablotronZone, JablotronCommon, JablotronCode
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -105,6 +105,13 @@ class JablotronEntity(Entity):
             last_mono = self._cu._device_last_active.get(device_id)
             if last_mono is not None and self._object.active:
                 attr["seconds_since_reported"] = round(time.monotonic() - last_mono)
+        # #83: surface when a code was last used (arm/disarm) as a non-breaking
+        # `last_used` attribute on the code entities, alongside the existing
+        # active/inactive state.
+        if isinstance(self._object, JablotronCode):
+            last_used = self._cu._code_last_used_wall.get(self._object._id)
+            if last_used is not None:
+                attr["last_used"] = last_used
         return attr
 
     @property

--- a/custom_components/jablotron80/logbook.py
+++ b/custom_components/jablotron80/logbook.py
@@ -1,0 +1,51 @@
+"""Logbook descriptions for jablotron80 events.
+
+#83/#98 follow-up: render the ``jablotron_code_used`` event as a logbook entry,
+linked to the code's ``binary_sensor`` entity so each code gets its own usage
+history (alongside the ``last_used`` attribute). Home Assistant's logbook
+integration auto-discovers this platform and calls ``async_describe_events``.
+"""
+
+from homeassistant.components.logbook import (
+    LOGBOOK_ENTRY_ENTITY_ID,
+    LOGBOOK_ENTRY_MESSAGE,
+    LOGBOOK_ENTRY_NAME,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
+
+from .const import DOMAIN, EVENT_CODE_USED
+
+
+@callback
+def async_describe_events(hass: HomeAssistant, async_describe_event) -> None:
+    """Describe jablotron80 logbook events."""
+
+    @callback
+    def async_describe_code_used(event):
+        data = event.data
+        # Prefer the entity_id carried on the event: the integration sets it so HA
+        # links the recorded event to the code's binary_sensor (the entity-scoped
+        # "Activity" filters on it). Fall back to resolving it from the unique_id.
+        entity_id = data.get("entity_id")
+        if not entity_id:
+            unique_id = data.get("unique_id")
+            if unique_id:
+                entity_id = er.async_get(hass).async_get_entity_id("binary_sensor", DOMAIN, unique_id)
+        # #83 follow-up: distinguish what the code was used for, when the integration
+        # knows it. arm/disarm come from different event paths; other code uses
+        # (e.g. panic/tamper) carry no action and stay the plain "was used".
+        action = data.get("action")
+        if action == "arm":
+            message = "was used to arm"
+        elif action == "disarm":
+            message = "was used to disarm"
+        else:
+            message = "was used"
+        return {
+            LOGBOOK_ENTRY_NAME: data.get("name") or "Code",
+            LOGBOOK_ENTRY_MESSAGE: message,
+            LOGBOOK_ENTRY_ENTITY_ID: entity_id,
+        }
+
+    async_describe_event(DOMAIN, EVENT_CODE_USED, async_describe_code_used)

--- a/tests/test_code_last_used.py
+++ b/tests/test_code_last_used.py
@@ -1,0 +1,224 @@
+"""Tests for the per-code "last used" timestamp (issue #83).
+
+Each code records a wall-clock timestamp whenever it is used (arm/disarm), and
+the code entities surface it as a non-breaking ``last_used`` attribute alongside
+the existing active/inactive state. This mirrors the detector
+``last_reported_active`` pattern.
+
+Stub note: like ``tests/test_battery.py``, importing ``jablotronHA`` pulls in
+extra Home Assistant helper modules that the shared conftest does not stub, so
+we provide the few needed symbols locally before importing ``JablotronEntity``.
+"""
+
+import datetime
+import sys
+import types
+
+import custom_components.jablotron80.jablotron as jablotron
+from custom_components.jablotron80.jablotron import JablotronCode
+from custom_components.jablotron80.const import (
+    CABLE_MODEL,
+    CABLE_MODEL_JA82T,
+    CONFIGURATION_PASSWORD,
+    CONFIGURATION_SERIAL_PORT,
+)
+
+
+def _ensure_module(name: str) -> types.ModuleType:
+    mod = sys.modules.get(name)
+    if mod is None:
+        mod = types.ModuleType(name)
+        sys.modules[name] = mod
+    return mod
+
+
+_entity = _ensure_module("homeassistant.helpers.entity")
+if not hasattr(_entity, "Entity"):
+
+    class Entity:  # noqa: D401 - dummy stand-in
+        """Minimal Entity stand-in."""
+
+    _entity.Entity = Entity
+
+_typing = _ensure_module("homeassistant.helpers.typing")
+if not hasattr(_typing, "StateType"):
+    _typing.StateType = object
+
+_restore = _ensure_module("homeassistant.helpers.restore_state")
+if not hasattr(_restore, "RestoreEntity"):
+
+    class RestoreEntity:  # noqa: D401 - dummy stand-in
+        """Minimal RestoreEntity stand-in."""
+
+    _restore.RestoreEntity = RestoreEntity
+
+_dispatcher = _ensure_module("homeassistant.helpers.dispatcher")
+if not hasattr(_dispatcher, "async_dispatcher_connect"):
+    _dispatcher.async_dispatcher_connect = lambda *a, **k: None
+
+from custom_components.jablotron80.jablotronHA import JablotronEntity  # noqa: E402
+
+# Internal code id 1 (panel source 0x41): a user code, not the admin code (id 0).
+CODE_ID = 1
+
+
+def _build_unit():
+    config = {
+        CABLE_MODEL: CABLE_MODEL_JA82T,
+        CONFIGURATION_SERIAL_PORT: "/dev/null",
+        CONFIGURATION_PASSWORD: "1234",
+    }
+    return jablotron.JA80CentralUnit(hass=None, config=config, options=None)
+
+
+def test_activate_code_records_last_used(event_loop_for_setters):
+    """Using a code records a recent tz-aware wall-clock timestamp."""
+    unit = _build_unit()
+    code = unit.get_code(CODE_ID)
+    assert isinstance(code, JablotronCode)
+
+    before = datetime.datetime.now(datetime.timezone.utc)
+    unit._activate_code_object(code)
+    after = datetime.datetime.now(datetime.timezone.utc)
+
+    assert code.active is True
+    assert CODE_ID in unit._code_last_used_wall
+    ts = unit._code_last_used_wall[CODE_ID]
+    assert isinstance(ts, datetime.datetime)
+    assert ts.tzinfo is not None
+    assert before <= ts <= after
+
+
+def test_code_entity_exposes_last_used(event_loop_for_setters):
+    """A used code exposes the last_used attribute equal to the recorded time."""
+    unit = _build_unit()
+    code = unit.get_code(CODE_ID)
+    unit._activate_code_object(code)
+
+    attr = JablotronEntity(unit, code).extra_state_attributes
+    assert "last_used" in attr
+    assert attr["last_used"] == unit._code_last_used_wall[CODE_ID]
+
+
+def test_unused_code_has_no_last_used(event_loop_for_setters):
+    """A code that has never been used exposes no last_used attribute."""
+    unit = _build_unit()
+    code = unit.get_code(CODE_ID)  # created but never activated
+
+    attr = JablotronEntity(unit, code).extra_state_attributes
+    assert "last_used" not in attr
+
+
+def test_code_use_fires_logbook_event(event_loop_for_setters):
+    """Using a code fires a single jablotron_code_used event for the logbook.
+
+    The event carries the code name and unique_id (logbook.py resolves the latter
+    to the code entity). It fires only on the off->on transition, so one entry
+    per use - a second activation while still active fires nothing more.
+    """
+    fired = []
+
+    class _Bus:
+        def async_fire(self, event_type, data):
+            fired.append((event_type, data))
+
+    unit = _build_unit()
+    unit._hass = type("_Hass", (), {"bus": _Bus()})()
+
+    code = unit.get_code(CODE_ID)
+    unit._activate_code_object(code)
+
+    assert len(fired) == 1
+    event_type, data = fired[0]
+    assert event_type == jablotron.EVENT_CODE_USED
+    assert data["code_id"] == CODE_ID
+    assert data["name"] == code.name
+    assert "unique_id" in data and str(CODE_ID) in data["unique_id"]
+    # entity_id is carried so HA links the recorded event to the code entity.
+    assert "entity_id" in data
+    # generic activation (no action passed) -> renders as plain "was used"
+    assert data.get("action") is None
+
+    # Still active -> a second activation does not fire another entry.
+    unit._activate_code_object(code)
+    assert len(fired) == 1
+
+
+def test_disarm_records_code_use_fires_event(event_loop_for_setters):
+    """Disarm (the _record_code_use path) records the use and fires one event.
+
+    The disarm handlers (0x09 Unsetting / 0x4E alarm cancelled) call
+    _record_code_use directly - on disarm the code is never activated, so this is
+    the only place the per-code logbook entry can originate. ``_record_code_use``
+    takes the raw panel source byte (code id 1 = 0x41 = 65).
+    """
+    fired = []
+
+    class _Bus:
+        def async_fire(self, event_type, data):
+            fired.append((event_type, data))
+
+    unit = _build_unit()
+    unit._hass = type("_Hass", (), {"bus": _Bus()})()
+
+    code = unit.get_code(CODE_ID)
+    before = datetime.datetime.now(datetime.timezone.utc)
+    unit._record_code_use(CODE_ID + 64)  # raw source byte for code id 1
+    after = datetime.datetime.now(datetime.timezone.utc)
+
+    assert len(fired) == 1
+    event_type, data = fired[0]
+    assert event_type == jablotron.EVENT_CODE_USED
+    assert data["code_id"] == CODE_ID
+    assert data["name"] == code.name
+    assert "unique_id" in data and str(CODE_ID) in data["unique_id"]
+    # entity_id is carried so HA links the recorded event to the code entity.
+    assert "entity_id" in data
+    # disarm path labels the action so the logbook says "was used to disarm"
+    assert data["action"] == "disarm"
+
+    # the use is recorded for last_used; the code stays inactive (disarm clears it).
+    assert CODE_ID in unit._code_last_used_wall
+    ts = unit._code_last_used_wall[CODE_ID]
+    assert before <= ts <= after
+    assert code.active is False
+
+
+def test_record_code_use_ignores_non_code(event_loop_for_setters):
+    """A device source (id < 0x40) is not a code use - no event, no timestamp."""
+    fired = []
+
+    class _Bus:
+        def async_fire(self, event_type, data):
+            fired.append((event_type, data))
+
+    unit = _build_unit()
+    unit._hass = type("_Hass", (), {"bus": _Bus()})()
+
+    unit._record_code_use(5)  # device id, not a code
+
+    assert fired == []
+    assert unit._code_last_used_wall == {}
+
+
+def test_arm_action_labels_event(event_loop_for_setters):
+    """The arm path passes action='arm' so the logbook can say 'was used to arm'.
+
+    Mirror of the disarm test: arm routes through _activate_code(..., action='arm')
+    -> _activate_code_object, which carries the action onto the fired event.
+    """
+    fired = []
+
+    class _Bus:
+        def async_fire(self, event_type, data):
+            fired.append((event_type, data))
+
+    unit = _build_unit()
+    unit._hass = type("_Hass", (), {"bus": _Bus()})()
+
+    code = unit.get_code(CODE_ID)
+    unit._activate_code_object(code, action="arm")
+
+    assert len(fired) == 1
+    _, data = fired[0]
+    assert data["action"] == "arm"


### PR DESCRIPTION
## What & why
Refs #83 - make it visible which user code armed or disarmed the system. Two
additive, read-only pieces:

- A `last_used` attribute on each code entity: the wall-clock time that code was
  last used to arm/disarm. Non-breaking - it sits alongside the existing
  attributes.
- A `jablotron_code_used` HA event fired on each fresh code use, plus a logbook
  platform (logbook.py) that renders it as a human-readable entry in HA's
  logbook - so the history shows who armed/disarmed, and when.

Nothing is written to the panel; this only surfaces information already carried
in the panel's events.

## Scope
This covers the logging / visibility side of #83. Mapping a code use to a proper
Home Assistant user (the "service user" angle) is out of scope here and stays
open - this uses the integration's existing code/user names only.

## Notes
- Fired once per fresh code use (arm, disarm, alarm-cancel); the logbook
  describer distinguishes the action.

## Tests / validation
tests/test_code_last_used.py covers the last_used tracking and the code-used
event; full suite green, black clean. Live on a JA-82K: arm/disarm by code
produces the logbook entry and updates the code's last_used attribute.