### PR TITLE
fix: bound every command that carries the access code (#219)

### DIFF
--- a/custom_components/jablotron80/jablotron.py
+++ b/custom_components/jablotron80/jablotron.py
@@ -653,6 +653,12 @@ class JablotronCommand:
     complete_prefix: str = None
     accepted_prefix: str = None
     max_records: int = 20
+    # Retry budget for the send loop: 2 retries = 3 attempts in total.
+    # Deliberately LOW by default. The arm/disarm key sequences carry the access
+    # code, and the panel starts a tamper (sabotage) alarm after 10 unsuccessful
+    # code entries in a row (JA-80K manual, 13.2). A rejected code must therefore
+    # never be hammered. Only the code-less "Details" query raises this budget.
+    max_retries: int = 2
 
     def __post_init__(self) -> None:
         self._event = asyncio.Event()
@@ -809,9 +815,12 @@ class JablotronConnection:
                 if send_cmd is not None:
                     accepted = False
                     confirmed = False
-                    # #153 (heifisch): more attempts so the detail query gets acked on flaky
-                    # comms; reconciliation only runs once a "Details" command is confirmed.
-                    retries = 10
+                    # Per-command retry budget (see JablotronCommand.max_retries).
+                    # The code-less "Details" query raises it so it still gets acked on
+                    # flaky links (#153). Everything carrying the access code keeps the
+                    # low default, so a rejected arm/disarm code is not re-sent into the
+                    # panel's "10 wrong entries in a row" tamper alarm.
+                    retries = send_cmd.max_retries
 
                     while retries >= 0 and not (accepted and confirmed):
                         for i in range(len(send_cmd.code)):
@@ -845,14 +854,34 @@ class JablotronConnection:
                                 else:
                                     if retries == 0:
                                         LOGGER.warning(f"no completion message found for command {send_cmd}")
-                                    send_cmd.confirm(False)
-                                    continue
+                                    # Fall through to the retry decrement below. This used to
+                                    # `continue`, which skipped the decrement and re-sent the
+                                    # sequence forever. Not academic: elevated mode
+                                    # ("*0" + master code) carries the code AND has a
+                                    # completion handshake, so an unconfirmed one hammered
+                                    # the code into the panel without any limit.
+                            else:
+                                # No completion handshake (the "Details" query and the
+                                # arm/disarm key sequences): the command is done the moment
+                                # it is accepted - there is nothing further to wait for.
+                                # Mark it confirmed so the loop exits now instead of
+                                # re-sending the same keypresses. For arm/disarm that
+                                # re-entry matters: the master code toggles arm/disarm, so
+                                # sending it again flips the state straight back.
+                                confirmed = True
 
                             send_cmd.confirm(True)
                             if send_cmd.name == "Details":
                                 self.update_devices = True
 
                         retries -= 1
+
+                    if not (accepted and confirmed):
+                        # Budget exhausted without the command ever succeeding. Report the
+                        # failure, otherwise anyone awaiting wait_for_confirmation() waits
+                        # forever - read_settings() does exactly that, during startup.
+                        LOGGER.warning(f"command {send_cmd} not confirmed after all retries")
+                        send_cmd.confirm(False)
 
                     self._cmd_q.task_done()
                     self._send_cmd = None
@@ -2950,7 +2979,15 @@ class JA80CentralUnit(object):
     async def send_return_mode_command(self) -> None:
         # if self.system_status in self.STATUS_ELEVATED:
         await self._connection.add_command(
-            JablotronCommand(name="Esc / back", code=b"\x8e", accepted_prefix=b"\xa1\xff")
+            JablotronCommand(
+                name="Esc / back",
+                code=b"\x8e",
+                accepted_prefix=b"\xa1\xff",
+                # Carries no access code, so re-sending cannot trip the panel's
+                # wrong-code tamper alarm - keep the generous budget. read_settings()
+                # relies on this to leave elevated mode again.
+                max_retries=10,
+            )
         )
 
     async def send_settings_command(self) -> None:
@@ -2959,6 +2996,10 @@ class JA80CentralUnit(object):
             name="Get settings",
             code=b"\x8a",
             accepted_prefix=b"\xa1\xff",
+            # Carries no access code either, and the panel acks only about one
+            # keypress in six - with the low default this would routinely exhaust
+            # its budget unacknowledged.
+            max_retries=10,
             complete_prefix=b"\xe6\x04",
             max_records=300,
         )
@@ -2967,7 +3008,16 @@ class JA80CentralUnit(object):
 
     async def send_detail_command(self) -> None:
         await self._connection.add_command(
-            JablotronCommand(name="Details", code=b"\x8e", accepted_prefix=b"\xa4\xff")
+            JablotronCommand(
+                name="Details",
+                code=b"\x8e",
+                accepted_prefix=b"\xa4\xff",
+                # #153: a generous budget so the query still gets acked on flaky links.
+                # Safe to raise here, and only here: unlike the arm/disarm sequences this
+                # command carries no access code, so re-sending it cannot trip the panel's
+                # wrong-code tamper alarm.
+                max_retries=10,
+            )
         )
 
     async def enter_elevated_mode(self, code: str) -> bool:

--- a/tests/test_code_retry_budget.py
+++ b/tests/test_code_retry_budget.py
@@ -1,0 +1,225 @@
+"""Retry budget for commands that carry the access code (#219, tamper alarm).
+
+The panel starts a tamper (sabotage) alarm after 10 unsuccessful code entries in a
+row (JA-80K installation manual). The send loop used a hard-coded ``retries = 10``
+for *every* command - i.e. up to 11 attempts - with two consequences:
+
+* a single mistyped code was re-sent 11 times, which exceeds that limit and trips
+  the sabotage alarm; and
+* an accepted code was re-sent as well (nothing marked it done), and since the
+  master code toggles arm/disarm, that flipped the state straight back.
+
+The budget is now per command: low by default (2 retries = 3 attempts) for anything
+carrying the code, raised only for the code-less "Details" query - which is what the
+generous budget was introduced for in the first place (#153).
+"""
+
+import custom_components.jablotron80.jablotron as jablotron
+from custom_components.jablotron80.jablotron import JablotronCommand
+from custom_components.jablotron80.const import (
+    CABLE_MODEL,
+    CABLE_MODEL_JA82T,
+    CONFIGURATION_PASSWORD,
+    CONFIGURATION_SERIAL_PORT,
+)
+
+# The prefix the panel acks every keypress with, except the last one of a sequence.
+INTERMEDIATE = b"\xa0\xff"
+
+
+def _build_conn():
+    config = {
+        CABLE_MODEL: CABLE_MODEL_JA82T,
+        CONFIGURATION_SERIAL_PORT: "/dev/null",
+        CONFIGURATION_PASSWORD: "1234",
+    }
+    unit = jablotron.JA80CentralUnit(hass=None, config=config, options=None)
+    return unit._connection
+
+
+class _Handle:
+    """Stand-in for the serial/HID handle."""
+
+    def write(self, data):
+        pass
+
+
+def _run(loop, conn, command, final_accepted: bool) -> int:
+    """Drive read_send_packet_loop for exactly one command.
+
+    The fake panel acks every intermediate keypress and answers the FINAL keypress of
+    the sequence with ``final_accepted`` - so ``False`` models a code the panel
+    rejects. Returns how many times the sequence reached its final keypress, which is
+    exactly how many complete code entries the panel sees.
+    """
+    conn._connection = _Handle()
+    entries = {"n": 0}
+
+    async def _fake_read_until_found(prefix, max_records=10):
+        if prefix == INTERMEDIATE:
+            return True
+        entries["n"] += 1
+        return final_accepted
+
+    async def _fake_read_data(*args, **kwargs):
+        return []
+
+    async def _noop():
+        return None
+
+    conn.read_until_found = _fake_read_until_found
+    conn._read_data = _fake_read_data
+    conn.disconnect = _noop
+
+    async def _drive():
+        conn._stop.set()  # exit the loop once the queue drains
+        await conn._cmd_q.put(command)
+        await conn.read_send_packet_loop()
+
+    jablotron._loop = loop
+    loop.run_until_complete(_drive())
+    return entries["n"]
+
+
+def _code_command() -> JablotronCommand:
+    """An arm/disarm key sequence: four code digits, no completion handshake."""
+    return JablotronCommand(
+        name="key sequence *HIDDEN*",
+        code=b"\x81\x82\x83\x84",
+        accepted_prefix=b"\xa1\xff",
+    )
+
+
+def test_default_budget_is_low():
+    """Any command that does not opt in gets the safe, low budget."""
+    assert JablotronCommand().max_retries == 2
+
+
+def test_rejected_code_is_not_hammered(event_loop_for_setters):
+    """A rejected code (a typo, say) must stay well under the panel's limit of 10
+    unsuccessful entries in a row - otherwise it trips the sabotage alarm."""
+    conn = _build_conn()
+
+    entries = _run(event_loop_for_setters, conn, _code_command(), final_accepted=False)
+
+    assert entries == 3  # the initial attempt plus 2 retries
+    assert entries < 10  # the panel's tamper threshold
+
+
+def test_accepted_code_is_sent_once(event_loop_for_setters):
+    """An accepted code must not be re-sent: the master code toggles arm/disarm, so a
+    second entry would flip the state straight back."""
+    conn = _build_conn()
+
+    entries = _run(event_loop_for_setters, conn, _code_command(), final_accepted=True)
+
+    assert entries == 1
+
+
+def test_detail_query_keeps_the_generous_budget(event_loop_for_setters):
+    """The code-less "Details" query keeps the full budget (#153): re-sending it
+    cannot trip the wrong-code tamper alarm, so raising it there is safe."""
+    conn = _build_conn()
+    details = JablotronCommand(
+        name="Details",
+        code=b"\x8e",
+        accepted_prefix=b"\xa4\xff",
+        max_retries=10,
+    )
+
+    entries = _run(event_loop_for_setters, conn, details, final_accepted=False)
+
+    assert entries == 11  # the initial attempt plus 10 retries
+
+
+def test_unaccepted_command_is_reported_as_failed(event_loop_for_setters):
+    """A command that is never accepted must still be marked failed.
+
+    Otherwise ``wait_for_confirmation()`` never returns - and ``read_settings()``
+    awaits exactly that during startup, so it would hang for good.
+    """
+    conn = _build_conn()
+    cmd = _code_command()
+
+    _run(event_loop_for_setters, conn, cmd, final_accepted=False)
+
+    assert cmd._event.is_set()
+    assert cmd._confirmed is False
+
+
+def _run_with_completion(loop, conn, command, completion_arrives: bool) -> int:
+    """Drive the loop for one command that has a completion handshake.
+
+    Every keypress is acked; the completion prefix answers ``completion_arrives``.
+    Returns how many complete code entries the panel saw.
+    """
+    conn._connection = _Handle()
+    entries = {"n": 0}
+
+    async def _fake_read_until_found(prefix, max_records=10):
+        if prefix == INTERMEDIATE:
+            return True
+        if prefix == command.complete_prefix:
+            return completion_arrives
+        entries["n"] += 1  # final keypress reached => one full entry went in
+        return True
+
+    async def _fake_read_data(*args, **kwargs):
+        return []
+
+    async def _noop():
+        return None
+
+    conn.read_until_found = _fake_read_until_found
+    conn._read_data = _fake_read_data
+    conn.disconnect = _noop
+
+    async def _drive():
+        conn._stop.set()
+        await conn._cmd_q.put(command)
+        await conn.read_send_packet_loop()
+
+    jablotron._loop = loop
+    loop.run_until_complete(_drive())
+    return entries["n"]
+
+
+def _elevated_mode_command() -> JablotronCommand:
+    """Shape of ``enter_elevated_mode``: "*0" + master code, WITH a completion
+    handshake. The one code-carrying command that waits for a completion prefix."""
+    return JablotronCommand(
+        name="key sequence *HIDDEN*",
+        code=b"\x8f\x80\x81\x82\x83\x84",
+        accepted_prefix=b"\xa1\xff",
+        complete_prefix=b"\xb8\xff",
+    )
+
+
+def test_completion_never_arrives_is_bounded(event_loop_for_setters):
+    """A command WITH a completion handshake must respect its budget too.
+
+    The retry decrement used to be skipped on this path (``continue``), so a command
+    whose completion never arrived re-sent its keypresses forever. Elevated mode
+    carries the master code and takes exactly this path, so "forever" meant
+    hammering the code into the panel without limit.
+    """
+    conn = _build_conn()
+    cmd = _elevated_mode_command()
+
+    entries = _run_with_completion(event_loop_for_setters, conn, cmd, completion_arrives=False)
+
+    assert entries == 3  # bounded by the budget
+    assert entries < 10  # and still under the panel's tamper threshold
+    assert cmd._event.is_set()
+    assert cmd._confirmed is False
+
+
+def test_completion_arrives_sends_once(event_loop_for_setters):
+    """The normal path is untouched: completion arrives, the command is done."""
+    conn = _build_conn()
+    cmd = _elevated_mode_command()
+
+    entries = _run_with_completion(event_loop_for_setters, conn, cmd, completion_arrives=True)
+
+    assert entries == 1
+    assert cmd._confirmed is True


### PR DESCRIPTION
Fixes #219. This is a regression I introduced in 01bd738 (merged via #204); releases **0.44 through 0.47** are affected. 0.43 and earlier are clean.

## The bug

The send loop used a hard-coded `retries = 10` - 11 attempts - for *every* queued command. The arm/disarm key sequences carry the user's access code, and the JA-80K installation manual is explicit:

> "The control panel allows a maximum of **10 unsuccessful attempts in a row** to enter a valid code or card. **If exceeded, a tamper alarm starts.**"

11 > 10, with two consequences:

1. **A rejected code was re-sent 11 times**, so a single mistyped code deterministically tripped the panel's sabotage alarm.
2. A command with no completion handshake never set `confirmed`, so an **accepted** code was re-sent for the whole budget too. The master code toggles arm/disarm, so those repeats flipped the state back and forth - the "extremely unreliable" symptom.

## Measured on a real JA-82K

Deliberate wrong code, keypress-level log, before and after:

| | before | after |
|---|---|---|
| complete code entries sent | **11** | **3** |
| duration | 17 s | 4 s |
| outcome | `Tampering key pad (wrong code?)` + `Tamper alarm`, zone -> Alarm | disarm simply fails, nothing else |

Before, the panel fired the tamper alarm after ~9 entries - and the loop kept sending twice more. Normal arm/disarm was re-tested and is unchanged.

## The changes

- **Retry budget is per command** (`JablotronCommand.max_retries`), defaulting to 2 retries (3 attempts) - safely under the panel's limit - for anything carrying the code.
- **"Details", "Esc / back" and "Get settings" opt into 10 retries.** None of them carries an access code, so re-sending cannot trip the wrong-code counter, and the panel acks only about one keypress in six. This preserves what the budget was raised for in #153.
- **A command with no completion handshake is confirmed once accepted**, so it is not re-sent at all.
- **The unconfirmed-completion path no longer `continue`s past the retry decrement.** It used to re-send forever, and `enter_elevated_mode` ("*0" + master code) carries the code *and* waits for a completion prefix - so that path hammered the code into the panel without any limit. This was found by an independent review of an earlier version of this patch.
- **An exhausted budget now reports failure.** Previously neither `confirm(True)` nor `confirm(False)` was called when a command was never accepted, so `wait_for_confirmation()` blocked forever - `read_settings()` awaits it during startup.

## Tests

`tests/test_code_retry_budget.py` covers the budgets (3 vs 11), the accepted-once case, both completion-handshake outcomes, and that an unconfirmable command is reported rather than left hanging. Full suite green, black clean.

## Validation

Beyond the deliberate wrong-code test above, this ran on a live JA-82K for three days: two nightly arm/disarm cycles, one service-mode session (which exercises the `enter_elevated_mode` path fixed here), zero budget exhaustions, zero tracebacks, no unexplained reconnects.